### PR TITLE
Implement #17 field context profile and migration-safe planner integration

### DIFF
--- a/docs/plans/2026-02-18-breadth-unresolved-issues-design.md
+++ b/docs/plans/2026-02-18-breadth-unresolved-issues-design.md
@@ -1,0 +1,320 @@
+# Farmer Breadth Unresolved Issues Design
+
+Date: 2026-02-18
+Status: Drafted for implementation
+Source: `docs/plans/2026-02-17-farmer-feature-breadth-design.md`
+Related issues: #17, #18, #19, #20, #21, #22, #23, #24
+
+## Goal
+
+Translate unresolved breadth features into implementation-ready technical plans with schema, UX, planner, and test strategy details.
+
+## Issue #17 - Field Context Profile for Plots
+
+### Objective
+
+Capture per-field context inputs so planning logic can reason about sun, drainage, wind, and terrain constraints.
+
+### Current Gap
+
+- `Field` only stores name, dimensions, and planted crops.
+- Planner utilities cannot account for microclimate/terrain constraints.
+
+### Proposed Design
+
+- Extend `Field` with `context`:
+  - `plotType`: `"open_field" | "raised_bed" | "container" | "greenhouse"`
+  - `sunHours`: `"lt4" | "h4_6" | "h6_8" | "gt8"`
+  - `drainage`: `"poor" | "moderate" | "good"`
+  - `slope`: `"flat" | "gentle" | "steep"`
+  - `windExposure`: `"sheltered" | "moderate" | "exposed"`
+- Add field defaults on create and migration fallback on existing local storage.
+- Update field create/edit dialog to support context selection.
+- Feed context into planner interfaces (`generatePlantingSuggestions`, task prioritizer explanation metadata).
+
+### Data Compatibility
+
+- Add defensive normalizer when loading fields from storage:
+  - Missing/invalid `context` gets default values.
+- Ensure event replay works without context in historical events by normalizing the final field state.
+
+### Test Plan
+
+- Unit test field normalizer for legacy field objects.
+- Unit test planner utility path that consumes field context and emits explanatory reason text.
+
+### Risks
+
+- Existing UI state may assume shallow field updates; verify partial update merges do not drop context.
+
+## Issue #18 - Soil Profile and Amendment History Model
+
+### Objective
+
+Move from free-text soil notes to structured soil profile data that the planner can consume.
+
+### Current Gap
+
+- Soil data exists as notes only (`SoilNote.content`, optional `ph`).
+- No structured EC, organic matter, texture, or amendment history.
+
+### Proposed Design
+
+- Add `soilProfile` per field:
+  - `texture`: `"sand" | "loam" | "clay" | "silty" | "mixed"`
+  - `ph`: number | null
+  - `ec`: number | null
+  - `organicMatterPct`: number | null
+  - `updatedAt`: ISO string
+- Add amendment history record:
+  - `id`, `fieldId`, `date`, `amendmentType`, `quantity`, `unit`, `notes`.
+- Keep existing `SoilNote` for narrative context.
+- Provide planner-facing projection:
+  - `soilRiskFlags` (acidic/alkaline/salinity/low-organic-matter hints).
+
+### UI Changes
+
+- Add structured soil profile card in farm management soil tab.
+- Add amendment entry form and recent amendment table.
+
+### Test Plan
+
+- Unit tests for profile validation/coercion and numeric bounds.
+- Unit tests for soil risk flag projection.
+- Storage migration tests from old shape to new profile defaults.
+
+### Risks
+
+- Overly strict validation may block valid farmer input; clamp + warn instead of hard reject where possible.
+
+## Issue #19 - Task Effort Model with Workload Bottleneck Forecast
+
+### Objective
+
+Attach effort semantics to tasks and expose workload bottleneck warnings.
+
+### Current Gap
+
+- Task schema has no effort, difficulty, or tool requirements.
+- Dashboard cannot forecast workload or over-capacity periods.
+
+### Proposed Design
+
+- Extend `Task` with:
+  - `effortMinutes?: number`
+  - `difficulty?: "low" | "medium" | "high"`
+  - `requiredTools?: string[]`
+- Implement `forecastWorkload(tasks, config)` utility:
+  - Aggregate effort per day/week over configurable horizon.
+  - Compute utilization against `dailyCapacityMinutes`.
+  - Emit `bottlenecks` with reason metadata.
+- Add dashboard card showing:
+  - next 7-day planned minutes
+  - top bottleneck day
+  - quick explanation.
+
+### Data Compatibility
+
+- Existing tasks without effort default via type-based heuristics in forecast only.
+
+### Test Plan
+
+- Unit tests for aggregation, fallback heuristics, and threshold crossing.
+- Edge tests for completed tasks and past-due tasks behavior.
+
+### Risks
+
+- Wrong default effort values can erode trust; include explanation source (`user`, `heuristic`, `fallback`).
+
+## Issue #20 - Harvest Forecast with Uncertainty Bands
+
+### Objective
+
+Provide probabilistic harvest windows instead of single-point countdowns.
+
+### Current Gap
+
+- Existing harvest countdown uses fixed growth day logic.
+- No uncertainty display tied to weather confidence or risk.
+
+### Proposed Design
+
+- Add utility `forecastHarvestWindow(plantedCrop, crop, signals)` returning:
+  - `earliestDate`, `likelyDate`, `latestDate`
+  - `confidence`: `"high" | "medium" | "low"`
+  - `factors`: explanation strings.
+- Inputs include:
+  - crop growth days
+  - crop stage/pest risk profile
+  - weather freshness/confidence from existing weather layer.
+- Surface in dashboard harvest module and crop timing dialog summary.
+
+### Degradation Strategy
+
+- If weather confidence unavailable, widen range and set confidence to `low` with clear reason.
+
+### Test Plan
+
+- Unit tests for baseline forecast and adverse weather widening behavior.
+- Unit tests for confidence downgrade when signals are stale.
+
+### Risks
+
+- Forecast complexity can be opaque; always attach factor list in UI tooltips.
+
+## Issue #21 - Automation Rules for Weather Anomalies and Replan Triggers
+
+### Objective
+
+Add rule-driven automation recommendations for anomaly conditions and key assumption changes.
+
+### Current Gap
+
+- Severe weather alerts exist, but schedule changes are mostly manual.
+- No centralized replan trigger evaluator.
+
+### Proposed Design
+
+- Introduce `automation/rules` module:
+  - `evaluateWeatherAnomalies(alerts, weather, tasks, fields)`
+  - `evaluateReplanTriggers(prevInputs, nextInputs)`
+- Rule outputs:
+  - suggested task adjustments (`delay`, `add`, `prioritize`)
+  - explanation and confidence
+  - `requiresConfirmation` boolean.
+- Beginner profile:
+  - conservative defaults turned on by opt-in flag in user settings/local storage.
+
+### Safety Constraints
+
+- No destructive task mutation without explicit user confirmation.
+- Suggestions are idempotent by deterministic rule id.
+
+### Test Plan
+
+- Unit tests for typhoon/heavy-rain/no-rain paths.
+- Unit tests verifying no-op when signal quality is insufficient.
+
+### Risks
+
+- Alert noise can overwhelm users; include simple suppression/cooldown per rule id.
+
+## Issue #22 - Farm-Wide CSV/JSON Import Export
+
+### Objective
+
+Enable complete farm data portability, backup, and restore workflows.
+
+### Current Gap
+
+- Only crop templates support JSON import/export.
+- No farm-wide schema version package.
+
+### Proposed Design
+
+- Add `exportFarmData()`:
+  - package fields, tasks, crop templates/custom crops, farm logs, metadata (`version`, `exportedAt`).
+- Add `importFarmData(payload, mode)`:
+  - mode: `"merge"` or `"replace"`
+  - validate each dataset via normalizers.
+- CSV export helpers:
+  - tasks, harvest logs, finance, weather logs.
+- Add import/export panel under farm management settings.
+
+### Validation and Migration
+
+- Keep backward compatibility with missing optional sections.
+- Unknown future sections ignored with warning list.
+
+### Test Plan
+
+- Unit tests for schema validation and merge/replace semantics.
+- Round-trip test: export then import yields equivalent normalized state.
+
+### Risks
+
+- Large JSON payloads in browser memory; stream-like handling can be deferred but avoid deep cloning loops.
+
+## Issue #23 - Outcome Logs with Quality Pest and Weather Impact
+
+### Objective
+
+Capture richer farming outcomes to improve planning explanations and retrospective analysis.
+
+### Current Gap
+
+- Harvest logs track quantity/unit/notes only.
+- No structured quality grade, pest incidents, or weather impact tags.
+
+### Proposed Design
+
+- Extend `HarvestLog`:
+  - `qualityGrade?: "A" | "B" | "C" | "reject"`
+  - `pestIncidentLevel?: "none" | "minor" | "moderate" | "severe"`
+  - `weatherImpact?: "none" | "heat" | "rain" | "wind" | "cold" | "mixed"`
+- Add summary utility:
+  - quality distribution
+  - weather impact frequency
+  - pest incident trend.
+- Integrate summary into farm management dashboard cards.
+
+### Data Compatibility
+
+- Old records default to null/`none` at read time; do not rewrite history unless edited.
+
+### Test Plan
+
+- Unit tests for summary aggregation and null-safe behavior.
+- Migration tests for old records.
+
+### Risks
+
+- Manual quality grading subjectivity; keep values coarse and optional.
+
+## Issue #24 - External Data Expansion Market Climate and Sensor Adapter Path
+
+### Objective
+
+Extend integration layer with adapter contracts beyond weather while preserving provider isolation.
+
+### Current Gap
+
+- Weather adapter exists.
+- No contracts for climate dataset, market price data, or sensor-style feeds.
+
+### Proposed Design
+
+- Define adapter interfaces:
+  - `ClimateProvider`
+  - `MarketPriceProvider`
+  - `SensorSnapshotProvider`
+- Standardize normalized envelope:
+  - `source`, `fetchedAt`, `freshness`, `confidence`, `payload`.
+- Implement mock providers and stub service orchestration.
+- Keep UI consumption provider-agnostic through integration service responses.
+
+### Reliability Rules
+
+- Adapter failures must not break local planner core.
+- Each response includes stale/missing status and fallback note.
+
+### Test Plan
+
+- Unit tests for normalization and confidence/freshness propagation.
+- Failure-path tests validating graceful degradation.
+
+### Risks
+
+- External provider contracts may evolve; isolate raw field mapping in adapter layer only.
+
+## Sequencing
+
+1. M1 first: #17, #18.
+2. M2 next: #19, #20, #21.
+3. M3 after M2 required items: #22, #23, #24.
+
+## Validation Baseline for Each Issue
+
+- `bun run lint`
+- `bunx tsc --noEmit`
+- `bun test`

--- a/src/components/dashboard/planting-suggestions.tsx
+++ b/src/components/dashboard/planting-suggestions.tsx
@@ -26,6 +26,7 @@ export function PlantingSuggestionsCard() {
     rotation: "bg-purple-100 text-purple-700",
     seasonal: "bg-green-100 text-green-700",
     "harvest-soon": "bg-amber-100 text-amber-700",
+    "field-context": "bg-rose-100 text-rose-700",
   };
 
   const typeLabel: Record<string, string> = {
@@ -33,6 +34,7 @@ export function PlantingSuggestionsCard() {
     rotation: "輪作",
     seasonal: "當季推薦",
     "harvest-soon": "即將收成",
+    "field-context": "田區條件",
   };
 
   return (

--- a/src/components/field-planner/field-settings-dialog.tsx
+++ b/src/components/field-planner/field-settings-dialog.tsx
@@ -4,6 +4,13 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -11,7 +18,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useFields } from "@/lib/store/fields-context";
-import type { Field } from "@/lib/types";
+import type { Field, FieldContext } from "@/lib/types";
+import { defaultFieldContext } from "@/lib/utils/field-context";
 import { Plus, Pencil } from "lucide-react";
 
 interface FieldSettingsDialogProps {
@@ -25,38 +33,56 @@ export function FieldSettingsDialog({ editField, occurredAt }: FieldSettingsDial
   const [name, setName] = useState("");
   const [width, setWidth] = useState("10");
   const [height, setHeight] = useState("5");
+  const [plotType, setPlotType] = useState<FieldContext["plotType"]>(defaultFieldContext.plotType);
+  const [sunHours, setSunHours] = useState<FieldContext["sunHours"]>(defaultFieldContext.sunHours);
+  const [drainage, setDrainage] = useState<FieldContext["drainage"]>(defaultFieldContext.drainage);
+  const [slope, setSlope] = useState<FieldContext["slope"]>(defaultFieldContext.slope);
+  const [windExposure, setWindExposure] = useState<FieldContext["windExposure"]>(defaultFieldContext.windExposure);
 
   const isEdit = !!editField;
+  const resetForm = () => {
+    setName("");
+    setWidth("10");
+    setHeight("5");
+    setPlotType(defaultFieldContext.plotType);
+    setSunHours(defaultFieldContext.sunHours);
+    setDrainage(defaultFieldContext.drainage);
+    setSlope(defaultFieldContext.slope);
+    setWindExposure(defaultFieldContext.windExposure);
+  };
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen && editField) {
       setName(editField.name);
       setWidth(String(editField.dimensions.width));
       setHeight(String(editField.dimensions.height));
+      setPlotType(editField.context.plotType);
+      setSunHours(editField.context.sunHours);
+      setDrainage(editField.context.drainage);
+      setSlope(editField.context.slope);
+      setWindExposure(editField.context.windExposure);
     }
     if (!nextOpen && !isEdit) {
-      setName("");
-      setWidth("10");
-      setHeight("5");
+      resetForm();
     }
     setOpen(nextOpen);
   };
 
   const handleSubmit = () => {
     if (!name || !width || !height) return;
+    const context: FieldContext = { plotType, sunHours, drainage, slope, windExposure };
     if (isEdit && editField) {
       updateField(editField.id, {
         name,
         dimensions: { width: parseFloat(width), height: parseFloat(height) },
+        context,
       }, { occurredAt });
     } else {
-      addField(name, parseFloat(width), parseFloat(height), { occurredAt });
+      addField(name, parseFloat(width), parseFloat(height), { occurredAt, context });
     }
     setOpen(false);
     if (!isEdit) {
-      setName("");
-      setWidth("10");
-      setHeight("5");
+      resetForm();
     }
   };
 
@@ -107,6 +133,80 @@ export function FieldSettingsDialog({ editField, occurredAt }: FieldSettingsDial
                 value={height}
                 onChange={(e) => setHeight(e.target.value)}
               />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">地塊類型</label>
+              <Select value={plotType} onValueChange={(value) => setPlotType(value as FieldContext["plotType"])}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="open_field">露地</SelectItem>
+                  <SelectItem value="raised_bed">高畦</SelectItem>
+                  <SelectItem value="container">容器</SelectItem>
+                  <SelectItem value="greenhouse">溫室</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">日照時數</label>
+              <Select value={sunHours} onValueChange={(value) => setSunHours(value as FieldContext["sunHours"])}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lt4">少於 4 小時</SelectItem>
+                  <SelectItem value="h4_6">4-6 小時</SelectItem>
+                  <SelectItem value="h6_8">6-8 小時</SelectItem>
+                  <SelectItem value="gt8">8 小時以上</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">排水</label>
+              <Select value={drainage} onValueChange={(value) => setDrainage(value as FieldContext["drainage"])}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="poor">差</SelectItem>
+                  <SelectItem value="moderate">中</SelectItem>
+                  <SelectItem value="good">佳</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">坡度</label>
+              <Select value={slope} onValueChange={(value) => setSlope(value as FieldContext["slope"])}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="flat">平坦</SelectItem>
+                  <SelectItem value="gentle">緩坡</SelectItem>
+                  <SelectItem value="steep">陡坡</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">風勢</label>
+              <Select
+                value={windExposure}
+                onValueChange={(value) => setWindExposure(value as FieldContext["windExposure"])}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="sheltered">避風</SelectItem>
+                  <SelectItem value="moderate">中等</SelectItem>
+                  <SelectItem value="exposed">強風</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
           <Button onClick={handleSubmit} disabled={!name} className="w-full">

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -93,10 +93,25 @@ export interface PlantedCrop {
   notes?: string;
 }
 
+export type FieldPlotType = "open_field" | "raised_bed" | "container" | "greenhouse";
+export type FieldSunHours = "lt4" | "h4_6" | "h6_8" | "gt8";
+export type FieldDrainage = "poor" | "moderate" | "good";
+export type FieldSlope = "flat" | "gentle" | "steep";
+export type FieldWindExposure = "sheltered" | "moderate" | "exposed";
+
+export interface FieldContext {
+  plotType: FieldPlotType;
+  sunHours: FieldSunHours;
+  drainage: FieldDrainage;
+  slope: FieldSlope;
+  windExposure: FieldWindExposure;
+}
+
 export interface Field {
   id: string;
   name: string;
   dimensions: { width: number; height: number }; // 公尺
+  context: FieldContext;
   plantedCrops: PlantedCrop[];
 }
 

--- a/src/lib/utils/field-context.test.ts
+++ b/src/lib/utils/field-context.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { SunlightLevel, type Field } from "@/lib/types";
+import { defaultFieldContext, isSunlightCompatible, normalizeField, normalizeFieldContext } from "@/lib/utils/field-context";
+
+describe("field context normalization", () => {
+  it("returns defaults when context is missing or invalid", () => {
+    expect(normalizeFieldContext()).toEqual(defaultFieldContext);
+    expect(normalizeFieldContext({ sunHours: "not-valid" as never })).toEqual(defaultFieldContext);
+  });
+
+  it("upgrades legacy field objects by injecting default context", () => {
+    const legacy = {
+      id: "field-1",
+      name: "A 區",
+      dimensions: { width: 5, height: 4 },
+      plantedCrops: [],
+    } as Omit<Field, "context">;
+
+    expect(normalizeField(legacy)).toEqual({
+      ...legacy,
+      context: defaultFieldContext,
+    });
+  });
+});
+
+describe("sunlight compatibility", () => {
+  it("flags full-sun crops as incompatible in low-sun fields", () => {
+    expect(isSunlightCompatible(SunlightLevel.全日照, "lt4")).toBe(false);
+    expect(isSunlightCompatible(SunlightLevel.全日照, "h6_8")).toBe(true);
+  });
+
+  it("allows shade crops in all sun bands", () => {
+    expect(isSunlightCompatible(SunlightLevel.耐陰, "lt4")).toBe(true);
+    expect(isSunlightCompatible(SunlightLevel.耐陰, "gt8")).toBe(true);
+  });
+});

--- a/src/lib/utils/field-context.ts
+++ b/src/lib/utils/field-context.ts
@@ -1,0 +1,58 @@
+import { SunlightLevel, type Field, type FieldContext, type FieldSunHours } from "@/lib/types";
+
+export const defaultFieldContext: FieldContext = {
+  plotType: "open_field",
+  sunHours: "h6_8",
+  drainage: "moderate",
+  slope: "flat",
+  windExposure: "moderate",
+};
+
+const plotTypeOptions = new Set<FieldContext["plotType"]>(["open_field", "raised_bed", "container", "greenhouse"]);
+const sunHoursOptions = new Set<FieldContext["sunHours"]>(["lt4", "h4_6", "h6_8", "gt8"]);
+const drainageOptions = new Set<FieldContext["drainage"]>(["poor", "moderate", "good"]);
+const slopeOptions = new Set<FieldContext["slope"]>(["flat", "gentle", "steep"]);
+const windOptions = new Set<FieldContext["windExposure"]>(["sheltered", "moderate", "exposed"]);
+
+export type LegacyField = Omit<Field, "context"> & { context?: Partial<FieldContext> | null };
+
+export function normalizeFieldContext(input?: Partial<FieldContext> | null): FieldContext {
+  const raw = input ?? {};
+  return {
+    plotType: plotTypeOptions.has(raw.plotType as FieldContext["plotType"]) ? raw.plotType! : defaultFieldContext.plotType,
+    sunHours: sunHoursOptions.has(raw.sunHours as FieldContext["sunHours"]) ? raw.sunHours! : defaultFieldContext.sunHours,
+    drainage: drainageOptions.has(raw.drainage as FieldContext["drainage"]) ? raw.drainage! : defaultFieldContext.drainage,
+    slope: slopeOptions.has(raw.slope as FieldContext["slope"]) ? raw.slope! : defaultFieldContext.slope,
+    windExposure: windOptions.has(raw.windExposure as FieldContext["windExposure"])
+      ? raw.windExposure!
+      : defaultFieldContext.windExposure,
+  };
+}
+
+export function normalizeField(field: LegacyField): Field {
+  return {
+    ...field,
+    context: normalizeFieldContext(field.context),
+  };
+}
+
+export function isSunlightCompatible(cropSunlight: SunlightLevel, sunHours: FieldSunHours): boolean {
+  if (cropSunlight === SunlightLevel.全日照) return sunHours === "h6_8" || sunHours === "gt8";
+  if (cropSunlight === SunlightLevel.半日照) return sunHours !== "lt4";
+  return true;
+}
+
+export function formatSunHoursLabel(sunHours: FieldSunHours): string {
+  switch (sunHours) {
+    case "lt4":
+      return "少於 4 小時";
+    case "h4_6":
+      return "4-6 小時";
+    case "h6_8":
+      return "6-8 小時";
+    case "gt8":
+      return "8 小時以上";
+    default:
+      return "未知";
+  }
+}

--- a/src/lib/utils/planting-suggestions.ts
+++ b/src/lib/utils/planting-suggestions.ts
@@ -1,9 +1,10 @@
 import type { Crop, Field } from "@/lib/types";
 import { rotationSuggestions } from "@/lib/data/crop-companions";
 import { addDays, differenceInDays } from "date-fns";
+import { formatSunHoursLabel, isSunlightCompatible } from "@/lib/utils/field-context";
 
 export interface PlantingSuggestion {
-  type: "pruning" | "rotation" | "seasonal" | "harvest-soon";
+  type: "pruning" | "rotation" | "seasonal" | "harvest-soon" | "field-context";
   title: string;
   description: string;
   cropId?: string;
@@ -48,6 +49,17 @@ export function generatePlantingSuggestions(
           type: "harvest-soon",
           title: `${crop.emoji} ${crop.name} 即將收成`,
           description: `${field.name} 的${crop.name}預計 ${daysUntilHarvest} 天後可收成。`,
+          cropId: crop.id,
+          cropName: crop.name,
+          fieldId: field.id,
+        });
+      }
+
+      if (!isSunlightCompatible(crop.sunlight, field.context.sunHours)) {
+        suggestions.push({
+          type: "field-context",
+          title: `${crop.emoji} ${crop.name} 可能日照不足`,
+          description: `${field.name} 目前日照 ${formatSunHoursLabel(field.context.sunHours)}，與${crop.name}需求（${crop.sunlight}）可能不匹配。`,
           cropId: crop.id,
           cropName: crop.name,
           fieldId: field.id,


### PR DESCRIPTION
## Summary
- add `Field.context` schema (`plotType`, `sunHours`, `drainage`, `slope`, `windExposure`) with migration-safe normalization
- update planner event replay/bootstrap and fields context so legacy field data is upgraded automatically
- extend field settings dialog to edit field context values
- consume field context in planting suggestions by adding sunlight compatibility warnings
- add issue-level depth plan doc for unresolved breadth backlog (#17-#24)

## Testing
- `bun run lint`
- `bun test`
- `bunx tsc --noEmit` *(blocked by existing missing deps in repo env: `next-auth`, `vitest`, `@neondatabase/serverless`, etc.)*

Closes #17
