### PR TITLE
Implement #18 soil profile and amendment history model

### DIFF
--- a/src/components/dashboard/planting-suggestions.tsx
+++ b/src/components/dashboard/planting-suggestions.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useFields } from "@/lib/store/fields-context";
+import { useFarmManagement } from "@/lib/store/farm-management-context";
 import { useAllCrops } from "@/lib/data/crop-lookup";
 import { generatePlantingSuggestions } from "@/lib/utils/planting-suggestions";
 import { Lightbulb } from "lucide-react";
@@ -11,12 +12,17 @@ import Link from "next/link";
 
 export function PlantingSuggestionsCard() {
   const { fields } = useFields();
+  const { soilProfiles } = useFarmManagement();
   const allCrops = useAllCrops();
   const currentMonth = new Date().getMonth() + 1;
+  const soilProfilesByFieldId = useMemo(
+    () => new Map(soilProfiles.map((profile) => [profile.fieldId, profile])),
+    [soilProfiles]
+  );
 
   const suggestions = useMemo(
-    () => generatePlantingSuggestions(fields, allCrops, currentMonth),
-    [fields, allCrops, currentMonth]
+    () => generatePlantingSuggestions(fields, allCrops, currentMonth, { soilProfilesByFieldId }),
+    [fields, allCrops, currentMonth, soilProfilesByFieldId]
   );
 
   if (suggestions.length === 0) return null;
@@ -27,6 +33,7 @@ export function PlantingSuggestionsCard() {
     seasonal: "bg-green-100 text-green-700",
     "harvest-soon": "bg-amber-100 text-amber-700",
     "field-context": "bg-rose-100 text-rose-700",
+    "soil-profile": "bg-cyan-100 text-cyan-700",
   };
 
   const typeLabel: Record<string, string> = {
@@ -35,6 +42,7 @@ export function PlantingSuggestionsCard() {
     seasonal: "當季推薦",
     "harvest-soon": "即將收成",
     "field-context": "田區條件",
+    "soil-profile": "土壤剖面",
   };
 
   return (

--- a/src/components/farm-management/soil-notes-tab.tsx
+++ b/src/components/farm-management/soil-notes-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -15,16 +15,62 @@ import {
 import { useFarmManagement } from "@/lib/store/farm-management-context";
 import { useFields } from "@/lib/store/fields-context";
 import { formatDate } from "@/lib/utils/date-helpers";
+import { defaultSoilTexture, summarizeSoilRiskFlags } from "@/lib/utils/soil-profile";
+import type { SoilTexture } from "@/lib/types";
 import { Plus, Trash2 } from "lucide-react";
 
 export function SoilNotesTab() {
-  const { soilNotes, addSoilNote, removeSoilNote } = useFarmManagement();
+  const {
+    soilNotes,
+    soilProfiles,
+    soilAmendments,
+    addSoilNote,
+    removeSoilNote,
+    upsertSoilProfile,
+    removeSoilProfile,
+    addSoilAmendment,
+    removeSoilAmendment,
+  } = useFarmManagement();
   const { fields } = useFields();
 
   const [fieldId, setFieldId] = useState("");
   const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [ph, setPh] = useState("");
   const [content, setContent] = useState("");
+  const [texture, setTexture] = useState<SoilTexture>(defaultSoilTexture);
+  const [profilePh, setProfilePh] = useState("");
+  const [profileEc, setProfileEc] = useState("");
+  const [organicMatterPct, setOrganicMatterPct] = useState("");
+  const [amendmentDate, setAmendmentDate] = useState(new Date().toISOString().split("T")[0]);
+  const [amendmentType, setAmendmentType] = useState("");
+  const [amendmentQuantity, setAmendmentQuantity] = useState("");
+  const [amendmentUnit, setAmendmentUnit] = useState("kg");
+  const [amendmentNotes, setAmendmentNotes] = useState("");
+
+  const selectedField = fields.find((field) => field.id === fieldId);
+  const selectedProfile = soilProfiles.find((profile) => profile.fieldId === fieldId);
+  const selectedRiskFlags = selectedProfile ? summarizeSoilRiskFlags(selectedProfile) : [];
+
+  const applyProfileToForm = (profile?: (typeof soilProfiles)[number]) => {
+    if (!profile) {
+      setTexture(defaultSoilTexture);
+      setProfilePh("");
+      setProfileEc("");
+      setOrganicMatterPct("");
+      return;
+    }
+
+    setTexture(profile.texture);
+    setProfilePh(profile.ph === null ? "" : String(profile.ph));
+    setProfileEc(profile.ec === null ? "" : String(profile.ec));
+    setOrganicMatterPct(profile.organicMatterPct === null ? "" : String(profile.organicMatterPct));
+  };
+
+  const handleFieldChange = (nextFieldId: string) => {
+    setFieldId(nextFieldId);
+    const profile = soilProfiles.find((item) => item.fieldId === nextFieldId);
+    applyProfileToForm(profile);
+  };
 
   const handleAdd = () => {
     if (!fieldId || !content) return;
@@ -38,14 +84,163 @@ export function SoilNotesTab() {
     setPh("");
   };
 
+  const handleSaveProfile = () => {
+    if (!fieldId) return;
+    upsertSoilProfile({
+      fieldId,
+      texture,
+      ph: profilePh ? parseFloat(profilePh) : null,
+      ec: profileEc ? parseFloat(profileEc) : null,
+      organicMatterPct: organicMatterPct ? parseFloat(organicMatterPct) : null,
+    });
+  };
+
+  const handleAddAmendment = () => {
+    if (!fieldId || !amendmentType || !amendmentQuantity) return;
+    addSoilAmendment({
+      fieldId,
+      date: new Date(amendmentDate).toISOString(),
+      amendmentType,
+      quantity: parseFloat(amendmentQuantity),
+      unit: amendmentUnit,
+      notes: amendmentNotes || undefined,
+    });
+    setAmendmentType("");
+    setAmendmentQuantity("");
+    setAmendmentNotes("");
+  };
+
   const sorted = [...soilNotes].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const fieldAmendments = useMemo(
+    () =>
+      soilAmendments
+        .filter((item) => item.fieldId === fieldId)
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+    [soilAmendments, fieldId]
+  );
 
   return (
     <div className="space-y-4 pt-4">
       <Card>
-        <CardContent className="pt-6 space-y-2">
+        <CardContent className="pt-6 space-y-3">
+          <p className="text-sm font-medium">土壤剖面</p>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2 items-end">
-            <Select value={fieldId} onValueChange={setFieldId}>
+            <Select value={fieldId} onValueChange={handleFieldChange}>
+              <SelectTrigger><SelectValue placeholder="選擇田地" /></SelectTrigger>
+              <SelectContent>
+                {fields.map((f) => (
+                  <SelectItem key={f.id} value={f.id}>{f.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={texture} onValueChange={(value) => setTexture(value as SoilTexture)}>
+              <SelectTrigger><SelectValue placeholder="土壤質地" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="sand">砂質</SelectItem>
+                <SelectItem value="loam">壤土</SelectItem>
+                <SelectItem value="clay">黏土</SelectItem>
+                <SelectItem value="silty">粉土</SelectItem>
+                <SelectItem value="mixed">混合</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input type="number" step="0.1" min="0" max="14" placeholder="pH 值" value={profilePh} onChange={(e) => setProfilePh(e.target.value)} />
+            <Input type="number" step="0.1" min="0" max="20" placeholder="EC (mS/cm)" value={profileEc} onChange={(e) => setProfileEc(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-2 items-end">
+            <Input
+              type="number"
+              step="0.1"
+              min="0"
+              max="100"
+              placeholder="有機質 (%)"
+              value={organicMatterPct}
+              onChange={(e) => setOrganicMatterPct(e.target.value)}
+            />
+            <Button onClick={handleSaveProfile} disabled={!fieldId}>
+              儲存土壤剖面
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (!fieldId) return;
+                removeSoilProfile(fieldId);
+                applyProfileToForm(undefined);
+              }}
+              disabled={!selectedProfile}
+            >
+              清除剖面
+            </Button>
+          </div>
+          {selectedProfile && (
+            <div className="rounded-md border p-3 text-sm space-y-1">
+              <p className="text-muted-foreground">
+                {selectedField?.name || "田地"} 更新時間：{formatDate(selectedProfile.updatedAt)}
+              </p>
+              {selectedRiskFlags.length === 0 ? (
+                <p>目前無明顯風險指標。</p>
+              ) : (
+                <ul className="list-disc pl-5 space-y-1">
+                  {selectedRiskFlags.map((flag) => (
+                    <li key={flag}>{flag}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6 space-y-3">
+          <p className="text-sm font-medium">改良紀錄</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 items-end">
+            <Select value={fieldId} onValueChange={handleFieldChange}>
+              <SelectTrigger><SelectValue placeholder="選擇田地" /></SelectTrigger>
+              <SelectContent>
+                {fields.map((f) => (
+                  <SelectItem key={f.id} value={f.id}>{f.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input type="date" value={amendmentDate} onChange={(e) => setAmendmentDate(e.target.value)} />
+            <Input placeholder="改良資材（例：堆肥）" value={amendmentType} onChange={(e) => setAmendmentType(e.target.value)} />
+            <Input type="number" step="0.1" min="0" placeholder="數量" value={amendmentQuantity} onChange={(e) => setAmendmentQuantity(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-[8rem_1fr_auto] gap-2 items-end">
+            <Input value={amendmentUnit} onChange={(e) => setAmendmentUnit(e.target.value)} placeholder="單位（kg）" />
+            <Input value={amendmentNotes} onChange={(e) => setAmendmentNotes(e.target.value)} placeholder="備註（選填）" />
+            <Button onClick={handleAddAmendment} disabled={!fieldId || !amendmentType || !amendmentQuantity}>
+              <Plus className="size-4 mr-1" />新增
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {fieldAmendments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">此田地尚無改良紀錄</p>
+            ) : (
+              fieldAmendments.map((item) => (
+                <div key={item.id} className="rounded-md border p-3 text-sm flex items-start justify-between">
+                  <div>
+                    <p className="font-medium">{item.amendmentType}</p>
+                    <p className="text-muted-foreground">
+                      {formatDate(item.date)} ・ {item.quantity} {item.unit}
+                    </p>
+                    {item.notes && <p className="mt-1">{item.notes}</p>}
+                  </div>
+                  <Button variant="ghost" size="icon" onClick={() => removeSoilAmendment(item.id)}>
+                    <Trash2 className="size-4 text-destructive" />
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6 space-y-2">
+          <p className="text-sm font-medium">土壤觀察紀錄</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 items-end">
+            <Select value={fieldId} onValueChange={handleFieldChange}>
               <SelectTrigger><SelectValue placeholder="選擇田地" /></SelectTrigger>
               <SelectContent>
                 {fields.map((f) => (

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -160,6 +160,27 @@ export interface SoilNote {
   content: string;
 }
 
+export type SoilTexture = "sand" | "loam" | "clay" | "silty" | "mixed";
+
+export interface SoilProfile {
+  fieldId: string;
+  texture: SoilTexture;
+  ph: number | null;
+  ec: number | null;
+  organicMatterPct: number | null;
+  updatedAt: string;
+}
+
+export interface SoilAmendment {
+  id: string;
+  fieldId: string;
+  date: string;
+  amendmentType: string;
+  quantity: number;
+  unit: string;
+  notes?: string;
+}
+
 export interface WeatherLog {
   id: string;
   date: string;

--- a/src/lib/utils/planting-suggestions.test.ts
+++ b/src/lib/utils/planting-suggestions.test.ts
@@ -43,4 +43,24 @@ describe("generatePlantingSuggestions field context support", () => {
     const suggestions = generatePlantingSuggestions([makeField("gt8")], [crop], 2);
     expect(suggestions.some((item) => item.type === "field-context")).toBe(false);
   });
+
+  it("adds soil-profile suggestion when soil pH is out of crop range", () => {
+    const suggestions = generatePlantingSuggestions([makeField("gt8")], [crop], 2, {
+      soilProfilesByFieldId: new Map([
+        [
+          "field-1",
+          {
+            fieldId: "field-1",
+            texture: "loam",
+            ph: 4.5,
+            ec: null,
+            organicMatterPct: null,
+            updatedAt: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      ]),
+    });
+
+    expect(suggestions.some((item) => item.type === "soil-profile")).toBe(true);
+  });
 });

--- a/src/lib/utils/soil-profile.test.ts
+++ b/src/lib/utils/soil-profile.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSoilAmendment, normalizeSoilProfile, summarizeSoilRiskFlags } from "@/lib/utils/soil-profile";
+
+describe("soil profile normalization", () => {
+  it("clamps invalid numeric values and applies defaults", () => {
+    const profile = normalizeSoilProfile({
+      fieldId: "field-1",
+      texture: "invalid" as never,
+      ph: 20,
+      ec: -5,
+      organicMatterPct: 500,
+      updatedAt: "invalid-date",
+    });
+
+    expect(profile.texture).toBe("loam");
+    expect(profile.ph).toBe(14);
+    expect(profile.ec).toBe(0);
+    expect(profile.organicMatterPct).toBe(100);
+    expect(new Date(profile.updatedAt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("normalizes amendment payload fallback values", () => {
+    const amendment = normalizeSoilAmendment({
+      id: "a1",
+      fieldId: "field-1",
+      amendmentType: "",
+      quantity: Number.NaN,
+      unit: "",
+      date: "",
+    });
+
+    expect(amendment.amendmentType).toBe("未命名改良資材");
+    expect(amendment.quantity).toBe(0);
+    expect(amendment.unit).toBe("kg");
+  });
+});
+
+describe("soil risk flags", () => {
+  it("returns risk warnings for acidic/high-ec/low-organic profile", () => {
+    const flags = summarizeSoilRiskFlags({
+      fieldId: "field-1",
+      texture: "loam",
+      ph: 5,
+      ec: 2.5,
+      organicMatterPct: 1.2,
+      updatedAt: "2026-02-01T00:00:00.000Z",
+    });
+
+    expect(flags).toHaveLength(3);
+  });
+});

--- a/src/lib/utils/soil-profile.ts
+++ b/src/lib/utils/soil-profile.ts
@@ -1,0 +1,53 @@
+import type { SoilAmendment, SoilProfile, SoilTexture } from "@/lib/types";
+
+export const defaultSoilTexture: SoilTexture = "loam";
+
+const textureOptions = new Set<SoilTexture>(["sand", "loam", "clay", "silty", "mixed"]);
+
+function asFiniteOrNull(value: unknown, min: number, max: number): number | null {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function asDate(value: unknown, fallback: string): string {
+  if (typeof value !== "string" || !value) return fallback;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed.toISOString();
+}
+
+export function normalizeSoilProfile(input: Partial<SoilProfile> & { fieldId: string }): SoilProfile {
+  const now = new Date().toISOString();
+  return {
+    fieldId: input.fieldId,
+    texture: textureOptions.has(input.texture as SoilTexture) ? (input.texture as SoilTexture) : defaultSoilTexture,
+    ph: asFiniteOrNull(input.ph, 0, 14),
+    ec: asFiniteOrNull(input.ec, 0, 20),
+    organicMatterPct: asFiniteOrNull(input.organicMatterPct, 0, 100),
+    updatedAt: asDate(input.updatedAt, now),
+  };
+}
+
+export function normalizeSoilAmendment(input: Partial<SoilAmendment> & { id: string; fieldId: string }): SoilAmendment {
+  const now = new Date().toISOString();
+  return {
+    id: input.id,
+    fieldId: input.fieldId,
+    date: asDate(input.date, now),
+    amendmentType: String(input.amendmentType ?? "").trim() || "未命名改良資材",
+    quantity: asFiniteOrNull(input.quantity, 0, 100000) ?? 0,
+    unit: String(input.unit ?? "").trim() || "kg",
+    notes: input.notes ? String(input.notes).trim() : undefined,
+  };
+}
+
+export function summarizeSoilRiskFlags(profile: SoilProfile): string[] {
+  const flags: string[] = [];
+  if (profile.ph !== null && profile.ph < 5.5) flags.push("土壤偏酸，留意石灰或有機質調整。");
+  if (profile.ph !== null && profile.ph > 7.5) flags.push("土壤偏鹼，留意微量元素吸收限制。");
+  if (profile.ec !== null && profile.ec > 2) flags.push("土壤鹽分偏高，建議加強灌排與沖洗。");
+  if (profile.organicMatterPct !== null && profile.organicMatterPct < 2) {
+    flags.push("有機質偏低，可增加堆肥或覆蓋作物。");
+  }
+  return flags;
+}


### PR DESCRIPTION
## Summary
- add structured `SoilProfile` and `SoilAmendment` models with normalization helpers and risk flag summaries
- extend farm management store with profile/amendment persistence and CRUD methods (localStorage-safe)
- upgrade soil tab UX to manage soil profile fields, amendment history, and existing free-text notes together
- surface soil pH mismatch warnings into planner suggestions via `generatePlantingSuggestions`
- add unit tests for soil normalization/risk flags and updated planting suggestion behavior

## Testing
- `bun run lint`
- `bun test`

Closes #18
