### PR TITLE
Implement #19 task effort model and workload bottleneck forecast

### DIFF
--- a/src/components/calendar/task-timeline.tsx
+++ b/src/components/calendar/task-timeline.tsx
@@ -71,7 +71,9 @@ export function TaskTimeline() {
                       <p className={`text-sm font-medium ${task.completed ? "line-through" : ""}`}>
                         {task.title}
                       </p>
-                      <p className="text-xs text-muted-foreground">{formatDate(task.dueDate)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDate(task.dueDate)} ・ {task.effortMinutes ?? 0} 分鐘
+                      </p>
                     </div>
                     <Badge variant="secondary" className="text-xs shrink-0">{task.type}</Badge>
                   </div>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -30,6 +30,8 @@ export enum TaskType {
   病蟲害防治 = "病蟲害防治",
 }
 
+export type TaskDifficulty = "low" | "medium" | "high";
+
 export interface Crop {
   id: string;
   name: string;
@@ -124,6 +126,9 @@ export interface Task {
   fieldId?: string;
   dueDate: string; // ISO date string
   completed: boolean;
+  effortMinutes?: number;
+  difficulty?: TaskDifficulty;
+  requiredTools?: string[];
   recurring?: {
     intervalDays: number;
     endDate?: string;

--- a/src/lib/utils/calendar-helpers.ts
+++ b/src/lib/utils/calendar-helpers.ts
@@ -2,6 +2,7 @@ import { addDays } from "date-fns";
 import type { Task } from "@/lib/types";
 import { TaskType } from "@/lib/types";
 import type { Crop, PlantedCrop } from "@/lib/types";
+import { getTaskEffortPreset } from "@/lib/utils/task-effort";
 
 export function generateTasksForPlantedCrop(
   crop: Crop,
@@ -19,6 +20,7 @@ export function generateTasksForPlantedCrop(
     plantedCropId: plantedCrop.id,
     fieldId: plantedCrop.fieldId,
     dueDate: plantedCrop.plantedDate,
+    ...getTaskEffortPreset(TaskType.播種),
   });
 
   // 定期施肥任務
@@ -32,6 +34,7 @@ export function generateTasksForPlantedCrop(
       plantedCropId: plantedCrop.id,
       fieldId: plantedCrop.fieldId,
       dueDate: fertDate.toISOString(),
+      ...getTaskEffortPreset(TaskType.施肥),
     });
     fertDate = addDays(fertDate, crop.fertilizerIntervalDays);
   }
@@ -49,6 +52,7 @@ export function generateTasksForPlantedCrop(
           plantedCropId: plantedCrop.id,
           fieldId: plantedCrop.fieldId,
           dueDate: checkDate.toISOString(),
+          ...getTaskEffortPreset(TaskType.剪枝),
         });
       }
     }
@@ -62,6 +66,7 @@ export function generateTasksForPlantedCrop(
     plantedCropId: plantedCrop.id,
     fieldId: plantedCrop.fieldId,
     dueDate: harvestDate.toISOString(),
+    ...getTaskEffortPreset(TaskType.收成),
   });
 
   // 防颱任務（生長期跨 6-10 月）
@@ -76,6 +81,7 @@ export function generateTasksForPlantedCrop(
         plantedCropId: plantedCrop.id,
         fieldId: plantedCrop.fieldId,
         dueDate: checkDate.toISOString(),
+        ...getTaskEffortPreset(TaskType.防颱),
       });
       break; // 只加一次防颱提醒
     }

--- a/src/lib/utils/task-effort.test.ts
+++ b/src/lib/utils/task-effort.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { TaskType, type Task } from "@/lib/types";
+import { normalizeTaskEffort, parseToolList } from "@/lib/utils/task-effort";
+
+describe("normalizeTaskEffort", () => {
+  it("fills effort defaults for legacy tasks", () => {
+    const task: Task = {
+      id: "t1",
+      type: TaskType.防颱,
+      title: "防颱",
+      cropId: "crop-1",
+      dueDate: "2026-02-18T00:00:00.000Z",
+      completed: false,
+    };
+
+    const normalized = normalizeTaskEffort(task);
+    expect(normalized.effortMinutes).toBe(90);
+    expect(normalized.difficulty).toBe("high");
+    expect(normalized.requiredTools?.length).toBeGreaterThan(0);
+  });
+});
+
+describe("parseToolList", () => {
+  it("splits and trims comma-separated input", () => {
+    expect(parseToolList(" 手鏟, 水管 ,, 剪刀 ")).toEqual(["手鏟", "水管", "剪刀"]);
+  });
+});

--- a/src/lib/utils/task-effort.ts
+++ b/src/lib/utils/task-effort.ts
@@ -1,0 +1,48 @@
+import type { Task, TaskDifficulty, TaskType } from "@/lib/types";
+
+export interface TaskEffortPreset {
+  effortMinutes: number;
+  difficulty: TaskDifficulty;
+  requiredTools: string[];
+}
+
+const TASK_EFFORT_PRESETS: Record<TaskType, TaskEffortPreset> = {
+  播種: { effortMinutes: 45, difficulty: "medium", requiredTools: ["手鏟"] },
+  施肥: { effortMinutes: 30, difficulty: "low", requiredTools: ["施肥器"] },
+  澆水: { effortMinutes: 20, difficulty: "low", requiredTools: ["水管"] },
+  剪枝: { effortMinutes: 35, difficulty: "medium", requiredTools: ["剪刀"] },
+  收成: { effortMinutes: 60, difficulty: "medium", requiredTools: ["採收籃"] },
+  防颱: { effortMinutes: 90, difficulty: "high", requiredTools: ["綁繩", "支架"] },
+  病蟲害防治: { effortMinutes: 50, difficulty: "medium", requiredTools: ["噴霧器"] },
+};
+
+const difficultySet = new Set<TaskDifficulty>(["low", "medium", "high"]);
+
+export function getTaskEffortPreset(type: TaskType): TaskEffortPreset {
+  return TASK_EFFORT_PRESETS[type];
+}
+
+export function normalizeTaskEffort(task: Task): Task {
+  const preset = getTaskEffortPreset(task.type);
+  const effortMinutes = Number.isFinite(task.effortMinutes) && (task.effortMinutes ?? 0) > 0
+    ? Math.min(480, Math.max(5, Number(task.effortMinutes)))
+    : preset.effortMinutes;
+  const difficulty = difficultySet.has(task.difficulty as TaskDifficulty) ? task.difficulty! : preset.difficulty;
+  const requiredTools = Array.isArray(task.requiredTools)
+    ? task.requiredTools.map((tool) => String(tool).trim()).filter(Boolean)
+    : preset.requiredTools;
+
+  return {
+    ...task,
+    effortMinutes,
+    difficulty,
+    requiredTools,
+  };
+}
+
+export function parseToolList(input: string): string[] {
+  return input
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/src/lib/utils/task-prioritizer.ts
+++ b/src/lib/utils/task-prioritizer.ts
@@ -47,6 +47,15 @@ function getRiskScore(task: Task, crop: Crop | undefined, now: Date) {
     score += crop?.pestSusceptibility === "高" ? 10 : crop?.pestSusceptibility === "中" ? 6 : 3;
   }
 
+  if ((task.effortMinutes ?? 0) >= 120) {
+    score += 8;
+  } else if ((task.effortMinutes ?? 0) >= 60) {
+    score += 4;
+  }
+
+  if (task.difficulty === "high") score += 6;
+  if (task.difficulty === "medium") score += 3;
+
   return score;
 }
 
@@ -62,6 +71,8 @@ function buildReasons(task: Task, crop: Crop | undefined, now: Date) {
   if (task.type === "防颱") reasons.push("降低天候損失風險");
   if (task.type === "病蟲害防治") reasons.push("降低病蟲害擴散風險");
   if (task.type === "澆水") reasons.push("維持作物生長穩定");
+  if ((task.effortMinutes ?? 0) >= 120) reasons.push("高工時任務，需預留時段");
+  if (task.difficulty === "high") reasons.push("執行難度高，建議優先安排");
 
   if (crop?.typhoonResistance === "低" && task.type === "防颱") reasons.push("作物抗風性較低");
   if (crop?.pestSusceptibility === "高" && task.type === "病蟲害防治") reasons.push("作物病蟲害敏感度高");

--- a/src/lib/utils/workload-forecast.test.ts
+++ b/src/lib/utils/workload-forecast.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { TaskType, type Task } from "@/lib/types";
+import { forecastWorkload } from "@/lib/utils/workload-forecast";
+
+function task(input: Partial<Task> & Pick<Task, "id" | "type" | "cropId" | "title" | "dueDate">): Task {
+  return {
+    completed: false,
+    ...input,
+  };
+}
+
+describe("forecastWorkload", () => {
+  it("emits bottleneck warnings when day load exceeds capacity", () => {
+    const now = new Date("2026-02-18T00:00:00.000Z");
+    const tasks: Task[] = [
+      task({ id: "a", type: TaskType.防颱, cropId: "crop-1", title: "A", dueDate: "2026-02-18T00:00:00.000Z", effortMinutes: 120 }),
+      task({ id: "b", type: TaskType.收成, cropId: "crop-1", title: "B", dueDate: "2026-02-18T00:00:00.000Z", effortMinutes: 90 }),
+    ];
+
+    const forecast = forecastWorkload(tasks, { now, dailyCapacityMinutes: 180, horizonDays: 7 });
+
+    expect(forecast.warnings).toHaveLength(1);
+    expect(forecast.warnings[0]?.overloadMinutes).toBe(30);
+  });
+
+  it("uses default effort presets when effortMinutes is not provided", () => {
+    const now = new Date("2026-02-18T00:00:00.000Z");
+    const tasks: Task[] = [
+      task({ id: "watering", type: TaskType.澆水, cropId: "crop-1", title: "澆水", dueDate: "2026-02-18T00:00:00.000Z" }),
+    ];
+
+    const forecast = forecastWorkload(tasks, { now, dailyCapacityMinutes: 200, horizonDays: 1 });
+
+    expect(forecast.totalMinutes).toBe(20);
+    expect(forecast.days[0]?.taskCount).toBe(1);
+  });
+
+  it("buckets overdue tasks into today by default", () => {
+    const now = new Date("2026-02-18T00:00:00.000Z");
+    const tasks: Task[] = [
+      task({ id: "overdue", type: TaskType.施肥, cropId: "crop-1", title: "overdue", dueDate: "2026-02-16T00:00:00.000Z", effortMinutes: 40 }),
+    ];
+
+    const forecast = forecastWorkload(tasks, { now, horizonDays: 1 });
+    expect(forecast.days[0]?.totalMinutes).toBe(40);
+  });
+});

--- a/src/lib/utils/workload-forecast.ts
+++ b/src/lib/utils/workload-forecast.ts
@@ -1,0 +1,116 @@
+import { addDays, differenceInCalendarDays, startOfDay } from "date-fns";
+import type { Task } from "@/lib/types";
+import { normalizeTaskEffort } from "@/lib/utils/task-effort";
+
+export interface WorkloadForecastConfig {
+  now?: Date;
+  horizonDays?: number;
+  dailyCapacityMinutes?: number;
+  includeOverdueInToday?: boolean;
+}
+
+export interface WorkloadForecastDay {
+  date: string;
+  totalMinutes: number;
+  taskCount: number;
+  utilizationPct: number;
+}
+
+export interface WorkloadBottleneckWarning {
+  date: string;
+  totalMinutes: number;
+  capacityMinutes: number;
+  overloadMinutes: number;
+  taskCount: number;
+}
+
+export interface WorkloadForecast {
+  days: WorkloadForecastDay[];
+  warnings: WorkloadBottleneckWarning[];
+  totalMinutes: number;
+  capacityMinutes: number;
+}
+
+function toDateKey(date: Date) {
+  return date.toISOString().split("T")[0];
+}
+
+export function forecastWorkload(tasks: Task[], config?: WorkloadForecastConfig): WorkloadForecast {
+  const now = startOfDay(config?.now ?? new Date());
+  const horizonDays = config?.horizonDays ?? 7;
+  const dailyCapacityMinutes = config?.dailyCapacityMinutes ?? 180;
+  const includeOverdueInToday = config?.includeOverdueInToday ?? true;
+  const horizonEnd = addDays(now, horizonDays - 1);
+
+  const days: WorkloadForecastDay[] = [];
+  const dayIndexByKey = new Map<string, number>();
+
+  for (let offset = 0; offset < horizonDays; offset += 1) {
+    const day = addDays(now, offset);
+    const date = toDateKey(day);
+    dayIndexByKey.set(date, offset);
+    days.push({
+      date,
+      totalMinutes: 0,
+      taskCount: 0,
+      utilizationPct: 0,
+    });
+  }
+
+  for (const rawTask of tasks) {
+    if (rawTask.completed) continue;
+    const task = normalizeTaskEffort(rawTask);
+    const due = startOfDay(new Date(task.dueDate));
+    if (Number.isNaN(due.getTime())) continue;
+
+    let bucketDate = due;
+    if (due < now) {
+      if (!includeOverdueInToday) continue;
+      bucketDate = now;
+    }
+    if (bucketDate > horizonEnd) continue;
+
+    const key = toDateKey(bucketDate);
+    const idx = dayIndexByKey.get(key);
+    if (idx === undefined) continue;
+
+    days[idx].totalMinutes += task.effortMinutes ?? 0;
+    days[idx].taskCount += 1;
+  }
+
+  for (const day of days) {
+    day.utilizationPct = Math.round((day.totalMinutes / dailyCapacityMinutes) * 100);
+  }
+
+  const warnings = days
+    .filter((day) => day.totalMinutes > dailyCapacityMinutes)
+    .map((day) => ({
+      date: day.date,
+      totalMinutes: day.totalMinutes,
+      capacityMinutes: dailyCapacityMinutes,
+      overloadMinutes: day.totalMinutes - dailyCapacityMinutes,
+      taskCount: day.taskCount,
+    }))
+    .sort((a, b) => b.overloadMinutes - a.overloadMinutes || a.date.localeCompare(b.date));
+
+  const totalMinutes = days.reduce((sum, day) => sum + day.totalMinutes, 0);
+  const capacityMinutes = horizonDays * dailyCapacityMinutes;
+
+  return {
+    days,
+    warnings,
+    totalMinutes,
+    capacityMinutes,
+  };
+}
+
+export function getTaskEffortSource(task: Task): "user" | "default" {
+  return Number.isFinite(task.effortMinutes) && (task.effortMinutes ?? 0) > 0 ? "user" : "default";
+}
+
+export function getWorkloadLeadDays(forecast: WorkloadForecast): number {
+  const firstBusyDay = forecast.days.find((day) => day.totalMinutes > 0);
+  if (!firstBusyDay) return -1;
+  const today = startOfDay(new Date());
+  return differenceInCalendarDays(new Date(`${firstBusyDay.date}T00:00:00.000Z`), today);
+}


### PR DESCRIPTION
## Summary
- extend `Task` schema with `effortMinutes`, `difficulty`, and `requiredTools`
- add task-effort presets + normalization to keep legacy task data backward compatible
- enrich manual task creation and auto-generated crop tasks with effort metadata
- introduce 7-day workload forecasting utility with bottleneck warnings against daily capacity
- surface workload forecast summary/warnings on dashboard and effort data in task timeline
- add unit tests for effort defaults/parsing and workload forecast behavior

## Testing
- `bun run lint`
- `bun test`

Closes #19
