### PR TITLE
Implement #20 harvest forecast with uncertainty bands

### DIFF
--- a/src/components/dashboard/harvest-countdown.tsx
+++ b/src/components/dashboard/harvest-countdown.tsx
@@ -1,34 +1,92 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useFields } from "@/lib/store/fields-context";
 import { useAllCrops } from "@/lib/data/crop-lookup";
-import { addDays, differenceInDays } from "date-fns";
+import { differenceInDays } from "date-fns";
+import { formatDate } from "@/lib/utils/date-helpers";
+import { forecastHarvestWindow, type HarvestForecastWeatherSignal } from "@/lib/utils/harvest-forecast";
 import { Timer } from "lucide-react";
 
 export function HarvestCountdown() {
   const { fields } = useFields();
   const allCrops = useAllCrops();
+  const [weatherSignal, setWeatherSignal] = useState<HarvestForecastWeatherSignal | null | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/weather")
+      .then(async (res) => {
+        if (!res.ok) throw new Error("weather request failed");
+        const data = await res.json();
+        if (cancelled) return;
+        const confidence = data?.meta?.confidence;
+        if (
+          confidence &&
+          (confidence.confidenceLevel === "low" || confidence.confidenceLevel === "medium" || confidence.confidenceLevel === "high") &&
+          (confidence.freshnessLabel === "fresh" || confidence.freshnessLabel === "stale" || confidence.freshnessLabel === "expired")
+        ) {
+          setWeatherSignal({
+            confidenceLevel: confidence.confidenceLevel,
+            freshnessLabel: confidence.freshnessLabel,
+          });
+          return;
+        }
+        setWeatherSignal(null);
+      })
+      .catch(() => {
+        if (!cancelled) setWeatherSignal(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const harvests = useMemo(() => {
     const today = new Date();
-    const items: { cropName: string; emoji: string; fieldName: string; daysLeft: number }[] = [];
+    const items: {
+      cropName: string;
+      emoji: string;
+      fieldName: string;
+      daysLeft: number;
+      earliestDate: Date;
+      likelyDate: Date;
+      latestDate: Date;
+      confidenceLevel: "low" | "medium" | "high";
+    }[] = [];
     for (const field of fields) {
       for (const planted of field.plantedCrops) {
         if (planted.status !== "growing") continue;
         const crop = allCrops.find((c) => c.id === planted.cropId);
         if (!crop) continue;
         const growthDays = planted.customGrowthDays ?? crop.growthDays;
-        const harvestDate = addDays(new Date(planted.plantedDate), growthDays);
-        const daysLeft = differenceInDays(harvestDate, today);
-        if (daysLeft >= 0) {
-          items.push({ cropName: crop.name, emoji: crop.emoji, fieldName: field.name, daysLeft });
+        const forecast = forecastHarvestWindow({
+          plantedDate: planted.plantedDate,
+          growthDays,
+          crop,
+          weatherSignal,
+          now: today,
+        });
+        const latestDaysLeft = differenceInDays(forecast.latestDate, today);
+        if (latestDaysLeft >= 0) {
+          items.push({
+            cropName: crop.name,
+            emoji: crop.emoji,
+            fieldName: field.name,
+            daysLeft: forecast.daysUntilLikely,
+            earliestDate: forecast.earliestDate,
+            likelyDate: forecast.likelyDate,
+            latestDate: forecast.latestDate,
+            confidenceLevel: forecast.confidenceLevel,
+          });
         }
       }
     }
     return items.sort((a, b) => a.daysLeft - b.daysLeft).slice(0, 5);
-  }, [fields, allCrops]);
+  }, [fields, allCrops, weatherSignal]);
 
   if (harvests.length === 0) return null;
 
@@ -48,6 +106,10 @@ export function HarvestCountdown() {
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium">{h.cropName}</p>
                 <p className="text-xs text-muted-foreground">{h.fieldName}</p>
+                <p className="text-[11px] text-muted-foreground">
+                  {formatDate(h.earliestDate)} - {formatDate(h.latestDate)} ・ 信心{" "}
+                  {h.confidenceLevel === "high" ? "高" : h.confidenceLevel === "medium" ? "中" : "低"}
+                </p>
               </div>
               <div className="text-right">
                 <p className={`text-sm font-bold ${h.daysLeft <= 7 ? "text-orange-600" : ""}`}>

--- a/src/lib/utils/harvest-forecast.test.ts
+++ b/src/lib/utils/harvest-forecast.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { CropCategory, SunlightLevel, WaterLevel, type Crop } from "@/lib/types";
+import { forecastHarvestWindow } from "@/lib/utils/harvest-forecast";
+
+const baseCrop: Crop = {
+  id: "crop-1",
+  name: "番茄",
+  emoji: "🍅",
+  color: "#f00",
+  schemaVersion: 2,
+  category: CropCategory.茄果類,
+  plantingMonths: [1, 2, 3],
+  harvestMonths: [4, 5, 6],
+  growthDays: 90,
+  spacing: { row: 60, plant: 40 },
+  water: WaterLevel.適量,
+  sunlight: SunlightLevel.全日照,
+  temperatureRange: { min: 18, max: 30 },
+  soilPhRange: { min: 6, max: 7 },
+  pestSusceptibility: "低",
+  yieldEstimateKgPerSqm: 3,
+  stageProfiles: {
+    seedling: { water: WaterLevel.適量, fertilizerIntervalDays: 12, pestRisk: "低" },
+    vegetative: { water: WaterLevel.適量, fertilizerIntervalDays: 12, pestRisk: "低" },
+  },
+  fertilizerIntervalDays: 14,
+  needsPruning: false,
+  pestControl: [],
+  typhoonResistance: "高",
+  hualienNotes: "",
+};
+
+describe("forecastHarvestWindow", () => {
+  it("keeps tighter range under high weather confidence and low agronomic risk", () => {
+    const result = forecastHarvestWindow({
+      plantedDate: "2026-02-01T00:00:00.000Z",
+      growthDays: 90,
+      crop: baseCrop,
+      weatherSignal: { confidenceLevel: "high", freshnessLabel: "fresh" },
+      now: new Date("2026-02-18T00:00:00.000Z"),
+    });
+
+    expect(result.uncertaintyDays).toBeLessThanOrEqual(8);
+    expect(result.confidenceLevel).toBe("high");
+  });
+
+  it("widens range and drops confidence under adverse weather signal and crop risk", () => {
+    const risky = { ...baseCrop, pestSusceptibility: "高" as const, typhoonResistance: "低" as const };
+    const result = forecastHarvestWindow({
+      plantedDate: "2026-02-01T00:00:00.000Z",
+      growthDays: 90,
+      crop: risky,
+      weatherSignal: { confidenceLevel: "low", freshnessLabel: "expired" },
+      now: new Date("2026-02-18T00:00:00.000Z"),
+    });
+
+    expect(result.uncertaintyDays).toBeGreaterThanOrEqual(16);
+    expect(result.confidenceLevel).toBe("low");
+  });
+
+  it("degrades gracefully when weather signal is missing", () => {
+    const result = forecastHarvestWindow({
+      plantedDate: "2026-02-01T00:00:00.000Z",
+      growthDays: 90,
+      crop: baseCrop,
+      weatherSignal: null,
+      now: new Date("2026-02-18T00:00:00.000Z"),
+    });
+
+    expect(result.uncertaintyDays).toBeGreaterThanOrEqual(10);
+    expect(result.factors.some((factor) => factor.includes("天氣信心資料缺失"))).toBe(true);
+  });
+});

--- a/src/lib/utils/harvest-forecast.ts
+++ b/src/lib/utils/harvest-forecast.ts
@@ -1,0 +1,120 @@
+import { addDays, differenceInCalendarDays } from "date-fns";
+import type { Crop, CropStageProfile } from "@/lib/types";
+
+export interface HarvestForecastWeatherSignal {
+  confidenceLevel: "low" | "medium" | "high";
+  freshnessLabel: "fresh" | "stale" | "expired";
+}
+
+export interface HarvestForecastInput {
+  plantedDate: string | Date;
+  growthDays: number;
+  crop: Crop;
+  weatherSignal?: HarvestForecastWeatherSignal | null;
+  now?: Date;
+}
+
+export interface HarvestForecast {
+  earliestDate: Date;
+  likelyDate: Date;
+  latestDate: Date;
+  confidenceLevel: "low" | "medium" | "high";
+  uncertaintyDays: number;
+  daysUntilLikely: number;
+  factors: string[];
+}
+
+function stageRiskBonus(stageProfiles: Partial<Record<string, CropStageProfile>>): number {
+  const entries = Object.values(stageProfiles).filter((profile): profile is CropStageProfile => Boolean(profile));
+  if (entries.length === 0) return 0;
+
+  const total = entries.reduce((sum, profile) => {
+    if (profile.pestRisk === "高") return sum + 2;
+    if (profile.pestRisk === "中") return sum + 1;
+    return sum;
+  }, 0);
+  return Math.round(total / entries.length);
+}
+
+function confidenceFromUncertainty(uncertaintyDays: number, weatherSignal?: HarvestForecastWeatherSignal | null) {
+  let score = 100 - uncertaintyDays * 4;
+  if (!weatherSignal) score -= 8;
+  if (weatherSignal?.confidenceLevel === "medium") score -= 8;
+  if (weatherSignal?.confidenceLevel === "low") score -= 16;
+  if (weatherSignal?.freshnessLabel === "stale") score -= 6;
+  if (weatherSignal?.freshnessLabel === "expired") score -= 14;
+  const normalized = Math.max(0, Math.min(100, score));
+  if (normalized >= 72) return "high";
+  if (normalized >= 46) return "medium";
+  return "low";
+}
+
+export function forecastHarvestWindow(input: HarvestForecastInput): HarvestForecast {
+  const now = input.now ?? new Date();
+  const plantedDate = new Date(input.plantedDate);
+  const growthDays = Math.max(1, input.growthDays);
+  const likelyDate = addDays(plantedDate, growthDays);
+  let uncertaintyDays = Math.max(3, Math.round(growthDays * 0.08));
+  const factors: string[] = [`以 ${growthDays} 天生長期為基準`];
+
+  if (input.crop.pestSusceptibility === "中") {
+    uncertaintyDays += 1;
+    factors.push("病蟲害敏感度中等，略提高不確定性");
+  } else if (input.crop.pestSusceptibility === "高") {
+    uncertaintyDays += 2;
+    factors.push("病蟲害敏感度高，採收時間波動較大");
+  }
+
+  if (input.crop.typhoonResistance === "中") {
+    uncertaintyDays += 1;
+    factors.push("抗風性中等，受天候影響較明顯");
+  } else if (input.crop.typhoonResistance === "低") {
+    uncertaintyDays += 2;
+    factors.push("抗風性偏低，颱風季不確定性增加");
+  }
+
+  const stageBonus = stageRiskBonus(input.crop.stageProfiles);
+  if (stageBonus > 0) {
+    uncertaintyDays += stageBonus;
+    factors.push("生育期病蟲風險設定提高預估區間");
+  }
+
+  if (!input.weatherSignal) {
+    uncertaintyDays += 4;
+    factors.push("天氣信心資料缺失，採保守寬區間");
+  } else {
+    if (input.weatherSignal.confidenceLevel === "medium") {
+      uncertaintyDays += 2;
+      factors.push("天氣信心中等，區間略放寬");
+    } else if (input.weatherSignal.confidenceLevel === "low") {
+      uncertaintyDays += 4;
+      factors.push("天氣信心偏低，區間明顯放寬");
+    } else {
+      uncertaintyDays = Math.max(2, uncertaintyDays - 1);
+      factors.push("天氣信心高，區間可適度收斂");
+    }
+
+    if (input.weatherSignal.freshnessLabel === "stale") {
+      uncertaintyDays += 1;
+      factors.push("天氣資料偏舊，增加不確定性");
+    } else if (input.weatherSignal.freshnessLabel === "expired") {
+      uncertaintyDays += 3;
+      factors.push("天氣資料過舊，採寬區間估計");
+    }
+  }
+
+  uncertaintyDays = Math.max(2, Math.min(28, uncertaintyDays));
+  const earliestDate = addDays(likelyDate, -uncertaintyDays);
+  const latestDate = addDays(likelyDate, uncertaintyDays);
+  const confidenceLevel = confidenceFromUncertainty(uncertaintyDays, input.weatherSignal);
+
+  return {
+    earliestDate,
+    likelyDate,
+    latestDate,
+    confidenceLevel,
+    uncertaintyDays,
+    daysUntilLikely: differenceInCalendarDays(likelyDate, now),
+    factors: factors.slice(0, 4),
+  };
+}


### PR DESCRIPTION
## Summary
- add `forecastHarvestWindow` utility that returns earliest/likely/latest harvest dates, uncertainty days, confidence level, and explanation factors
- uncertainty now incorporates crop risk signals and weather confidence freshness from existing weather metadata
- integrate forecast range + confidence display into dashboard harvest countdown card
- gracefully degrade when weather confidence metadata is missing by widening forecast range and lowering confidence
- add unit tests for stable/high-confidence, adverse/low-confidence, and missing-weather scenarios

## Testing
- `bun run lint`
- `bun test`

Closes #20
