### PR TITLE
Implement #22 farm-wide CSV/JSON import-export

### DIFF
--- a/src/app/farm-management/page.tsx
+++ b/src/app/farm-management/page.tsx
@@ -8,6 +8,7 @@ import { FinanceTab } from "@/components/farm-management/finance-tab";
 import { SoilNotesTab } from "@/components/farm-management/soil-notes-tab";
 import { WeatherTab } from "@/components/farm-management/weather-tab";
 import { RotationTab } from "@/components/farm-management/rotation-tab";
+import { DataTransferPanel } from "@/components/farm-management/data-transfer-panel";
 
 function FarmManagementContent() {
   const searchParams = useSearchParams();
@@ -40,6 +41,7 @@ export default function FarmManagementPage() {
       </div>
 
       <Suspense fallback={<div className="text-center py-8 text-muted-foreground">載入中...</div>}>
+        <DataTransferPanel />
         <FarmManagementContent />
       </Suspense>
     </div>

--- a/src/components/farm-management/data-transfer-panel.tsx
+++ b/src/components/farm-management/data-transfer-panel.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useFields } from "@/lib/store/fields-context";
+import { useTasks } from "@/lib/store/tasks-context";
+import { useCustomCrops } from "@/lib/store/custom-crops-context";
+import { useFarmManagement } from "@/lib/store/farm-management-context";
+import {
+  applyFarmDataImport,
+  buildFarmDataPackage,
+  exportFinanceCsv,
+  exportHarvestCsv,
+  exportTasksCsv,
+  parseFarmDataPackage,
+  type FarmImportMode,
+} from "@/lib/utils/farm-data-transfer";
+
+const STORAGE_KEYS = {
+  plannerEvents: "hualien-planner-events",
+  tasks: "hualien-tasks",
+  customCrops: "hualien-custom-crops",
+  cropTemplates: "hualien-crop-templates",
+  harvestLogs: "hualien-harvest-logs",
+  financeRecords: "hualien-finance",
+  soilNotes: "hualien-soil-notes",
+  soilProfiles: "hualien-soil-profiles",
+  soilAmendments: "hualien-soil-amendments",
+  weatherLogs: "hualien-weather-logs",
+} as const;
+
+function downloadText(filename: string, content: string, mimeType = "application/json") {
+  const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function DataTransferPanel() {
+  const { plannerEvents } = useFields();
+  const { tasks } = useTasks();
+  const { customCrops, cropTemplates } = useCustomCrops();
+  const { harvestLogs, financeRecords, soilNotes, soilProfiles, soilAmendments, weatherLogs } = useFarmManagement();
+  const [importText, setImportText] = useState("");
+  const [importMode, setImportMode] = useState<FarmImportMode>("merge");
+  const [status, setStatus] = useState<string | null>(null);
+
+  const snapshot = useMemo(
+    () => ({
+      plannerEvents,
+      tasks,
+      customCrops,
+      cropTemplates,
+      harvestLogs,
+      financeRecords,
+      soilNotes,
+      soilProfiles,
+      soilAmendments,
+      weatherLogs,
+    }),
+    [
+      plannerEvents,
+      tasks,
+      customCrops,
+      cropTemplates,
+      harvestLogs,
+      financeRecords,
+      soilNotes,
+      soilProfiles,
+      soilAmendments,
+      weatherLogs,
+    ]
+  );
+
+  const handleExportJson = () => {
+    const payload = buildFarmDataPackage(snapshot);
+    downloadText(
+      `farm-data-${new Date().toISOString().slice(0, 10)}.json`,
+      JSON.stringify(payload, null, 2),
+      "application/json"
+    );
+    setStatus("已匯出完整 JSON。");
+  };
+
+  const handleImport = () => {
+    try {
+      if (importMode === "replace") {
+        const confirmed = window.confirm("Replace 會覆蓋匯入中包含的資料集，確定要繼續嗎？");
+        if (!confirmed) return;
+      }
+
+      const parsed = parseFarmDataPackage(importText);
+      const next = applyFarmDataImport(snapshot, parsed.snapshot, importMode);
+
+      window.localStorage.setItem(STORAGE_KEYS.plannerEvents, JSON.stringify(next.plannerEvents));
+      window.localStorage.setItem(STORAGE_KEYS.tasks, JSON.stringify(next.tasks));
+      window.localStorage.setItem(STORAGE_KEYS.customCrops, JSON.stringify(next.customCrops));
+      window.localStorage.setItem(STORAGE_KEYS.cropTemplates, JSON.stringify(next.cropTemplates));
+      window.localStorage.setItem(STORAGE_KEYS.harvestLogs, JSON.stringify(next.harvestLogs));
+      window.localStorage.setItem(STORAGE_KEYS.financeRecords, JSON.stringify(next.financeRecords));
+      window.localStorage.setItem(STORAGE_KEYS.soilNotes, JSON.stringify(next.soilNotes));
+      window.localStorage.setItem(STORAGE_KEYS.soilProfiles, JSON.stringify(next.soilProfiles));
+      window.localStorage.setItem(STORAGE_KEYS.soilAmendments, JSON.stringify(next.soilAmendments));
+      window.localStorage.setItem(STORAGE_KEYS.weatherLogs, JSON.stringify(next.weatherLogs));
+
+      const warningText = parsed.warnings.length > 0 ? `（警告：${parsed.warnings.join("；")}）` : "";
+      setStatus(`匯入成功，正在重新整理資料 ${warningText}`);
+      window.setTimeout(() => window.location.reload(), 400);
+    } catch {
+      setStatus("匯入失敗：JSON 格式或資料內容不正確。");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">資料匯入匯出</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" variant="outline" onClick={handleExportJson}>
+            匯出完整 JSON
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => downloadText("tasks.csv", exportTasksCsv(tasks), "text/csv")}>
+            匯出 Tasks CSV
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => downloadText("harvest-logs.csv", exportHarvestCsv(harvestLogs), "text/csv")}
+          >
+            匯出 Harvest CSV
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => downloadText("finance-records.csv", exportFinanceCsv(financeRecords), "text/csv")}
+          >
+            匯出 Finance CSV
+          </Button>
+        </div>
+
+        <div className="rounded-md border p-3 space-y-2">
+          <p className="text-sm font-medium">匯入 JSON</p>
+          <div className="flex items-center gap-4 text-sm">
+            <label className="inline-flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="import-mode"
+                checked={importMode === "merge"}
+                onChange={() => setImportMode("merge")}
+              />
+              Merge（保留既有資料）
+            </label>
+            <label className="inline-flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="import-mode"
+                checked={importMode === "replace"}
+                onChange={() => setImportMode("replace")}
+              />
+              Replace（覆蓋匯入資料集）
+            </label>
+          </div>
+          <Textarea
+            rows={8}
+            placeholder='貼上 farm-data JSON（支援舊版含 "fields" 的匯出）'
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+          />
+          <Button size="sm" onClick={handleImport} disabled={!importText.trim()}>
+            套用匯入
+          </Button>
+          {status && <p className="text-xs text-muted-foreground">{status}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/utils/farm-data-transfer.test.ts
+++ b/src/lib/utils/farm-data-transfer.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/lib/types";
+import {
+  applyFarmDataImport,
+  exportFinanceCsv,
+  exportHarvestCsv,
+  exportTasksCsv,
+  parseFarmDataPackage,
+  type FarmDataSnapshot,
+} from "@/lib/utils/farm-data-transfer";
+
+function baseSnapshot(): FarmDataSnapshot {
+  return {
+    plannerEvents: [],
+    tasks: [],
+    customCrops: [],
+    cropTemplates: [],
+    harvestLogs: [],
+    financeRecords: [],
+    soilNotes: [],
+    soilProfiles: [],
+    soilAmendments: [],
+    weatherLogs: [],
+  };
+}
+
+describe("parseFarmDataPackage", () => {
+  it("supports legacy fields payload by converting to plannerEvents", () => {
+    const parsed = parseFarmDataPackage(
+      JSON.stringify({
+        version: 1,
+        exportedAt: "2026-02-01T00:00:00.000Z",
+        data: {
+          fields: [{ id: "field-1", name: "A 區", dimensions: { width: 5, height: 4 }, plantedCrops: [] }],
+        },
+      })
+    );
+
+    expect(parsed.snapshot.plannerEvents?.length).toBeGreaterThan(0);
+    expect(parsed.warnings.some((item) => item.includes("legacy fields"))).toBe(true);
+  });
+});
+
+describe("applyFarmDataImport", () => {
+  it("merges by id in merge mode", () => {
+    const current = baseSnapshot();
+    current.tasks = [
+      {
+        id: "old",
+        type: "澆水",
+        title: "old",
+        cropId: "crop-1",
+        dueDate: "2026-02-20T00:00:00.000Z",
+        completed: false,
+      } as Task,
+    ];
+
+    const merged = applyFarmDataImport(
+      current,
+      {
+        tasks: [
+          {
+            id: "new",
+            type: "施肥",
+            title: "new",
+            cropId: "crop-1",
+            dueDate: "2026-02-21T00:00:00.000Z",
+            completed: false,
+          } as Task,
+        ],
+      },
+      "merge"
+    );
+
+    expect(merged.tasks.map((task) => task.id).sort()).toEqual(["new", "old"]);
+  });
+
+  it("replaces included sections in replace mode while preserving unspecified sections", () => {
+    const current = baseSnapshot();
+    current.tasks = [
+      {
+        id: "old",
+        type: "澆水",
+        title: "old",
+        cropId: "crop-1",
+        dueDate: "2026-02-20T00:00:00.000Z",
+        completed: false,
+      } as Task,
+    ];
+    current.weatherLogs = [{ id: "w1", date: "2026-02-20T00:00:00.000Z" }];
+
+    const replaced = applyFarmDataImport(
+      current,
+      {
+        tasks: [
+          {
+            id: "incoming",
+            type: "施肥",
+            title: "incoming",
+            cropId: "crop-1",
+            dueDate: "2026-02-21T00:00:00.000Z",
+            completed: false,
+          } as Task,
+        ],
+      },
+      "replace"
+    );
+
+    expect(replaced.tasks.map((task) => task.id)).toEqual(["incoming"]);
+    expect(replaced.weatherLogs).toHaveLength(1);
+  });
+});
+
+describe("CSV exporters", () => {
+  it("includes headers and serialized rows", () => {
+    const tasksCsv = exportTasksCsv([
+      {
+        id: "t1",
+        type: "澆水",
+        title: "澆水任務",
+        cropId: "crop-1",
+        dueDate: "2026-02-20T00:00:00.000Z",
+        completed: false,
+      } as Task,
+    ]);
+    expect(tasksCsv.split("\n")[0]).toContain("id,type,title");
+
+    const harvestCsv = exportHarvestCsv([
+      { id: "h1", fieldId: "f1", cropId: "c1", date: "2026-02-20T00:00:00.000Z", quantity: 3.2, unit: "kg" },
+    ]);
+    expect(harvestCsv.split("\n")).toHaveLength(2);
+
+    const financeCsv = exportFinanceCsv([
+      { id: "r1", type: "expense", category: "seed", amount: 100, date: "2026-02-20T00:00:00.000Z", description: "seed" },
+    ]);
+    expect(financeCsv.split("\n")[1]).toContain("expense");
+  });
+});

--- a/src/lib/utils/farm-data-transfer.ts
+++ b/src/lib/utils/farm-data-transfer.ts
@@ -1,0 +1,364 @@
+import type {
+  CropTemplate,
+  CustomCrop,
+  FinanceRecord,
+  HarvestLog,
+  SoilAmendment,
+  SoilNote,
+  SoilProfile,
+  Task,
+  WeatherLog,
+} from "@/lib/types";
+import { normalizeCustomCrop } from "@/lib/data/crop-schema";
+import { normalizeTaskEffort } from "@/lib/utils/task-effort";
+import { normalizeSoilAmendment, normalizeSoilProfile } from "@/lib/utils/soil-profile";
+import {
+  bootstrapEventsFromFields,
+  type PlannerEvent,
+  type PlannerEventType,
+} from "@/lib/planner/events";
+import { normalizeField, type LegacyField } from "@/lib/utils/field-context";
+
+export type FarmImportMode = "merge" | "replace";
+
+export interface FarmDataSnapshot {
+  plannerEvents: PlannerEvent[];
+  tasks: Task[];
+  customCrops: CustomCrop[];
+  cropTemplates: CropTemplate[];
+  harvestLogs: HarvestLog[];
+  financeRecords: FinanceRecord[];
+  soilNotes: SoilNote[];
+  soilProfiles: SoilProfile[];
+  soilAmendments: SoilAmendment[];
+  weatherLogs: WeatherLog[];
+}
+
+export interface FarmDataPackage {
+  version: 1;
+  exportedAt: string;
+  data: Partial<FarmDataSnapshot> & { fields?: LegacyField[] };
+}
+
+export interface ParsedFarmData {
+  snapshot: Partial<FarmDataSnapshot>;
+  warnings: string[];
+}
+
+const PLANNER_EVENT_TYPES = new Set<PlannerEventType>([
+  "field_created",
+  "field_updated",
+  "field_removed",
+  "crop_planted",
+  "crop_updated",
+  "crop_removed",
+  "crop_harvested",
+]);
+
+function asIsoDate(value: unknown, fallback = new Date().toISOString()) {
+  if (typeof value !== "string") return fallback;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed.toISOString();
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item)).filter(Boolean);
+}
+
+function normalizePlannerEvents(value: unknown): PlannerEvent[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((event) => typeof event.id === "string" && PLANNER_EVENT_TYPES.has(event.type as PlannerEventType))
+    .map((event) => ({
+      id: String(event.id),
+      type: event.type as PlannerEventType,
+      occurredAt: asIsoDate(event.occurredAt),
+      insertedAt: typeof event.insertedAt === "string" ? asIsoDate(event.insertedAt) : undefined,
+      fieldId: typeof event.fieldId === "string" ? event.fieldId : undefined,
+      cropId: typeof event.cropId === "string" ? event.cropId : undefined,
+      payload: event.payload ?? {},
+    }));
+}
+
+function normalizeTasks(value: unknown): Task[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((task) => typeof task.id === "string" && typeof task.title === "string" && typeof task.type === "string")
+    .map((task) =>
+      normalizeTaskEffort({
+        id: String(task.id),
+        type: task.type as Task["type"],
+        title: String(task.title),
+        cropId: String(task.cropId ?? ""),
+        plantedCropId: typeof task.plantedCropId === "string" ? task.plantedCropId : undefined,
+        fieldId: typeof task.fieldId === "string" ? task.fieldId : undefined,
+        dueDate: asIsoDate(task.dueDate),
+        completed: Boolean(task.completed),
+        effortMinutes: typeof task.effortMinutes === "number" ? task.effortMinutes : undefined,
+        difficulty:
+          task.difficulty === "low" || task.difficulty === "medium" || task.difficulty === "high"
+            ? task.difficulty
+            : undefined,
+        requiredTools: toStringArray(task.requiredTools),
+        recurring:
+          task.recurring && typeof task.recurring === "object"
+            ? {
+                intervalDays: Number((task.recurring as Record<string, unknown>).intervalDays ?? 0) || 0,
+                endDate:
+                  typeof (task.recurring as Record<string, unknown>).endDate === "string"
+                    ? asIsoDate((task.recurring as Record<string, unknown>).endDate)
+                    : undefined,
+              }
+            : undefined,
+      })
+    );
+}
+
+function normalizeCustomCrops(value: unknown): CustomCrop[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((crop) => typeof crop.id === "string" && typeof crop.name === "string" && typeof crop.category === "string")
+    .map((crop) => normalizeCustomCrop(crop as Partial<CustomCrop> & { id: string; name: string; category: CustomCrop["category"] }));
+}
+
+function normalizeTemplates(value: unknown): CropTemplate[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((template) => typeof template.id === "string" && typeof template.name === "string")
+    .map((template) => ({
+      id: String(template.id),
+      name: String(template.name),
+      createdAt: asIsoDate(template.createdAt),
+      crops: normalizeCustomCrops(template.crops),
+    }));
+}
+
+function normalizeHarvestLogs(value: unknown): HarvestLog[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((log) => typeof log.id === "string" && typeof log.fieldId === "string" && typeof log.cropId === "string")
+    .map((log) => ({
+      id: String(log.id),
+      plantedCropId: typeof log.plantedCropId === "string" ? log.plantedCropId : undefined,
+      fieldId: String(log.fieldId),
+      cropId: String(log.cropId),
+      date: asIsoDate(log.date),
+      quantity: Number(log.quantity ?? 0) || 0,
+      unit: String(log.unit ?? "kg"),
+      notes: typeof log.notes === "string" ? log.notes : undefined,
+    }));
+}
+
+function normalizeFinanceRecords(value: unknown): FinanceRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((record) => typeof record.id === "string" && typeof record.type === "string")
+    .map((record) => ({
+      id: String(record.id),
+      type: record.type === "income" ? "income" : "expense",
+      category: String(record.category ?? "其他"),
+      amount: Number(record.amount ?? 0) || 0,
+      date: asIsoDate(record.date),
+      description: String(record.description ?? ""),
+      relatedFieldId: typeof record.relatedFieldId === "string" ? record.relatedFieldId : undefined,
+      relatedCropId: typeof record.relatedCropId === "string" ? record.relatedCropId : undefined,
+    }));
+}
+
+function normalizeSoilNotes(value: unknown): SoilNote[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((note) => typeof note.id === "string" && typeof note.fieldId === "string")
+    .map((note) => ({
+      id: String(note.id),
+      fieldId: String(note.fieldId),
+      date: asIsoDate(note.date),
+      ph: typeof note.ph === "number" ? note.ph : undefined,
+      content: String(note.content ?? ""),
+    }));
+}
+
+function normalizeSoilProfiles(value: unknown): SoilProfile[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((profile) => typeof profile.fieldId === "string")
+    .map((profile) => normalizeSoilProfile(profile as Partial<SoilProfile> & { fieldId: string }));
+}
+
+function normalizeSoilAmendments(value: unknown): SoilAmendment[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((amendment) => typeof amendment.id === "string" && typeof amendment.fieldId === "string")
+    .map((amendment) =>
+      normalizeSoilAmendment(amendment as Partial<SoilAmendment> & { id: string; fieldId: string })
+    );
+}
+
+function normalizeWeatherLogs(value: unknown): WeatherLog[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => item as Record<string, unknown>)
+    .filter((log) => typeof log.id === "string")
+    .map((log) => ({
+      id: String(log.id),
+      date: asIsoDate(log.date),
+      temperature: typeof log.temperature === "number" ? log.temperature : undefined,
+      rainfall: typeof log.rainfall === "number" ? log.rainfall : undefined,
+      condition: typeof log.condition === "string" ? log.condition : undefined,
+      notes: typeof log.notes === "string" ? log.notes : undefined,
+    }));
+}
+
+function mergeById<T extends { id: string }>(current: T[], incoming: T[], mode: FarmImportMode): T[] {
+  if (mode === "replace") return incoming;
+  const byId = new Map(current.map((item) => [item.id, item]));
+  for (const item of incoming) byId.set(item.id, item);
+  return Array.from(byId.values());
+}
+
+function mergeByFieldId<T extends { fieldId: string }>(current: T[], incoming: T[], mode: FarmImportMode): T[] {
+  if (mode === "replace") return incoming;
+  const byField = new Map(current.map((item) => [item.fieldId, item]));
+  for (const item of incoming) byField.set(item.fieldId, item);
+  return Array.from(byField.values());
+}
+
+export function buildFarmDataPackage(snapshot: FarmDataSnapshot): FarmDataPackage {
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    data: snapshot,
+  };
+}
+
+export function parseFarmDataPackage(jsonText: string): ParsedFarmData {
+  const raw = JSON.parse(jsonText) as Partial<FarmDataPackage> & { data?: Record<string, unknown> };
+  const data = raw.data ?? {};
+  const warnings: string[] = [];
+  const snapshot: Partial<FarmDataSnapshot> = {};
+
+  const plannerEvents = normalizePlannerEvents(data.plannerEvents);
+  if (plannerEvents.length > 0) {
+    snapshot.plannerEvents = plannerEvents;
+  } else if (Array.isArray(data.fields)) {
+    snapshot.plannerEvents = bootstrapEventsFromFields(data.fields.map((field) => normalizeField(field as LegacyField)));
+    warnings.push("使用相容模式：由 legacy fields 轉換為 plannerEvents。");
+  }
+
+  if ("tasks" in data) snapshot.tasks = normalizeTasks(data.tasks);
+  if ("customCrops" in data) snapshot.customCrops = normalizeCustomCrops(data.customCrops);
+  if ("cropTemplates" in data) snapshot.cropTemplates = normalizeTemplates(data.cropTemplates);
+  if ("harvestLogs" in data) snapshot.harvestLogs = normalizeHarvestLogs(data.harvestLogs);
+  if ("financeRecords" in data) snapshot.financeRecords = normalizeFinanceRecords(data.financeRecords);
+  if ("soilNotes" in data) snapshot.soilNotes = normalizeSoilNotes(data.soilNotes);
+  if ("soilProfiles" in data) snapshot.soilProfiles = normalizeSoilProfiles(data.soilProfiles);
+  if ("soilAmendments" in data) snapshot.soilAmendments = normalizeSoilAmendments(data.soilAmendments);
+  if ("weatherLogs" in data) snapshot.weatherLogs = normalizeWeatherLogs(data.weatherLogs);
+
+  return { snapshot, warnings };
+}
+
+export function applyFarmDataImport(
+  current: FarmDataSnapshot,
+  incoming: Partial<FarmDataSnapshot>,
+  mode: FarmImportMode
+): FarmDataSnapshot {
+  return {
+    plannerEvents: incoming.plannerEvents ? mergeById(current.plannerEvents, incoming.plannerEvents, mode) : current.plannerEvents,
+    tasks: incoming.tasks ? mergeById(current.tasks, incoming.tasks, mode) : current.tasks,
+    customCrops: incoming.customCrops ? mergeById(current.customCrops, incoming.customCrops, mode) : current.customCrops,
+    cropTemplates: incoming.cropTemplates ? mergeById(current.cropTemplates, incoming.cropTemplates, mode) : current.cropTemplates,
+    harvestLogs: incoming.harvestLogs ? mergeById(current.harvestLogs, incoming.harvestLogs, mode) : current.harvestLogs,
+    financeRecords: incoming.financeRecords
+      ? mergeById(current.financeRecords, incoming.financeRecords, mode)
+      : current.financeRecords,
+    soilNotes: incoming.soilNotes ? mergeById(current.soilNotes, incoming.soilNotes, mode) : current.soilNotes,
+    soilProfiles: incoming.soilProfiles
+      ? mergeByFieldId(current.soilProfiles, incoming.soilProfiles, mode)
+      : current.soilProfiles,
+    soilAmendments: incoming.soilAmendments
+      ? mergeById(current.soilAmendments, incoming.soilAmendments, mode)
+      : current.soilAmendments,
+    weatherLogs: incoming.weatherLogs ? mergeById(current.weatherLogs, incoming.weatherLogs, mode) : current.weatherLogs,
+  };
+}
+
+function escapeCsv(value: unknown): string {
+  const text = String(value ?? "");
+  if (text.includes(",") || text.includes("\"") || text.includes("\n")) {
+    return `"${text.replaceAll("\"", "\"\"")}"`;
+  }
+  return text;
+}
+
+function toCsv(headers: string[], rows: string[][]): string {
+  return [headers.join(","), ...rows.map((row) => row.map((value) => escapeCsv(value)).join(","))].join("\n");
+}
+
+export function exportTasksCsv(tasks: Task[]): string {
+  return toCsv(
+    ["id", "type", "title", "cropId", "dueDate", "completed", "effortMinutes", "difficulty", "requiredTools"],
+    tasks.map((task) => [
+      task.id,
+      task.type,
+      task.title,
+      task.cropId,
+      task.dueDate,
+      String(task.completed),
+      String(task.effortMinutes ?? ""),
+      String(task.difficulty ?? ""),
+      (task.requiredTools ?? []).join("|"),
+    ])
+  );
+}
+
+export function exportHarvestCsv(harvestLogs: HarvestLog[]): string {
+  return toCsv(
+    ["id", "fieldId", "cropId", "date", "quantity", "unit", "notes"],
+    harvestLogs.map((log) => [
+      log.id,
+      log.fieldId,
+      log.cropId,
+      log.date,
+      String(log.quantity),
+      log.unit,
+      log.notes ?? "",
+    ])
+  );
+}
+
+export function exportFinanceCsv(financeRecords: FinanceRecord[]): string {
+  return toCsv(
+    ["id", "type", "category", "amount", "date", "description", "relatedFieldId", "relatedCropId"],
+    financeRecords.map((record) => [
+      record.id,
+      record.type,
+      record.category,
+      String(record.amount),
+      record.date,
+      record.description,
+      record.relatedFieldId ?? "",
+      record.relatedCropId ?? "",
+    ])
+  );
+}


### PR DESCRIPTION
## Summary
- add farm-wide data transfer utility with versioned JSON package support (`version: 1`)
- support backward-compatible import parsing, including legacy `fields` conversion into planner events
- add guarded import application with `merge` vs `replace` semantics for included datasets
- add CSV exports for tasks, harvest logs, and finance records
- add farm management UI panel for JSON export/import and CSV download actions
- add unit tests for legacy parsing, merge/replace behavior, and CSV serialization

## Testing
- `bun run lint`
- `bun test`

Closes #22
