### PR TITLE
Implement #23 enriched outcome logs and summaries

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -143,6 +143,9 @@ export interface HarvestLog {
   date: string;
   quantity: number;
   unit: string;
+  qualityGrade?: "A" | "B" | "C" | "reject";
+  pestIncidentLevel?: "none" | "minor" | "moderate" | "severe";
+  weatherImpact?: "none" | "heat" | "rain" | "wind" | "cold" | "mixed";
   notes?: string;
 }
 

--- a/src/lib/utils/farm-data-transfer.ts
+++ b/src/lib/utils/farm-data-transfer.ts
@@ -12,6 +12,7 @@ import type {
 import { normalizeCustomCrop } from "@/lib/data/crop-schema";
 import { normalizeTaskEffort } from "@/lib/utils/task-effort";
 import { normalizeSoilAmendment, normalizeSoilProfile } from "@/lib/utils/soil-profile";
+import { normalizeHarvestLog } from "@/lib/utils/outcome-logs";
 import {
   bootstrapEventsFromFields,
   type PlannerEvent,
@@ -156,8 +157,13 @@ function normalizeHarvestLogs(value: unknown): HarvestLog[] {
       date: asIsoDate(log.date),
       quantity: Number(log.quantity ?? 0) || 0,
       unit: String(log.unit ?? "kg"),
+      qualityGrade: typeof log.qualityGrade === "string" ? (log.qualityGrade as HarvestLog["qualityGrade"]) : undefined,
+      pestIncidentLevel:
+        typeof log.pestIncidentLevel === "string" ? (log.pestIncidentLevel as HarvestLog["pestIncidentLevel"]) : undefined,
+      weatherImpact: typeof log.weatherImpact === "string" ? (log.weatherImpact as HarvestLog["weatherImpact"]) : undefined,
       notes: typeof log.notes === "string" ? log.notes : undefined,
-    }));
+    }))
+    .map((log) => normalizeHarvestLog(log));
 }
 
 function normalizeFinanceRecords(value: unknown): FinanceRecord[] {
@@ -334,7 +340,7 @@ export function exportTasksCsv(tasks: Task[]): string {
 
 export function exportHarvestCsv(harvestLogs: HarvestLog[]): string {
   return toCsv(
-    ["id", "fieldId", "cropId", "date", "quantity", "unit", "notes"],
+    ["id", "fieldId", "cropId", "date", "quantity", "unit", "qualityGrade", "pestIncidentLevel", "weatherImpact", "notes"],
     harvestLogs.map((log) => [
       log.id,
       log.fieldId,
@@ -342,6 +348,9 @@ export function exportHarvestCsv(harvestLogs: HarvestLog[]): string {
       log.date,
       String(log.quantity),
       log.unit,
+      String(log.qualityGrade ?? ""),
+      String(log.pestIncidentLevel ?? ""),
+      String(log.weatherImpact ?? ""),
       log.notes ?? "",
     ])
   );

--- a/src/lib/utils/outcome-logs.test.ts
+++ b/src/lib/utils/outcome-logs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHarvestLog, summarizeOutcomeLogs } from "@/lib/utils/outcome-logs";
+
+describe("normalizeHarvestLog", () => {
+  it("fills defaults for legacy harvest logs without enriched fields", () => {
+    const normalized = normalizeHarvestLog({
+      id: "h1",
+      fieldId: "field-1",
+      cropId: "crop-1",
+      date: "2026-02-20T00:00:00.000Z",
+      quantity: 3,
+      unit: "公斤",
+    });
+
+    expect(normalized.qualityGrade).toBe("B");
+    expect(normalized.pestIncidentLevel).toBe("none");
+    expect(normalized.weatherImpact).toBe("none");
+  });
+});
+
+describe("summarizeOutcomeLogs", () => {
+  it("aggregates quality, pest incidents and weather impact counts", () => {
+    const summary = summarizeOutcomeLogs([
+      {
+        id: "h1",
+        fieldId: "field-1",
+        cropId: "crop-1",
+        date: "2026-02-20T00:00:00.000Z",
+        quantity: 3,
+        unit: "公斤",
+        qualityGrade: "A",
+        pestIncidentLevel: "minor",
+        weatherImpact: "rain",
+      },
+      {
+        id: "h2",
+        fieldId: "field-1",
+        cropId: "crop-1",
+        date: "2026-02-21T00:00:00.000Z",
+        quantity: 2,
+        unit: "公斤",
+      },
+    ]);
+
+    expect(summary.qualityCounts.A).toBe(1);
+    expect(summary.qualityCounts.B).toBe(1);
+    expect(summary.pestCounts.minor).toBe(1);
+    expect(summary.pestCounts.none).toBe(1);
+    expect(summary.weatherImpactCounts.rain).toBe(1);
+    expect(summary.weatherImpactCounts.none).toBe(1);
+  });
+});

--- a/src/lib/utils/outcome-logs.ts
+++ b/src/lib/utils/outcome-logs.ts
@@ -1,0 +1,54 @@
+import type { HarvestLog } from "@/lib/types";
+
+export interface OutcomeSummary {
+  qualityCounts: Record<"A" | "B" | "C" | "reject", number>;
+  pestCounts: Record<"none" | "minor" | "moderate" | "severe", number>;
+  weatherImpactCounts: Record<"none" | "heat" | "rain" | "wind" | "cold" | "mixed", number>;
+}
+
+const QUALITY_DEFAULT: NonNullable<HarvestLog["qualityGrade"]> = "B";
+const PEST_DEFAULT: NonNullable<HarvestLog["pestIncidentLevel"]> = "none";
+const WEATHER_DEFAULT: NonNullable<HarvestLog["weatherImpact"]> = "none";
+
+export function normalizeHarvestLog(log: HarvestLog): HarvestLog {
+  return {
+    ...log,
+    qualityGrade:
+      log.qualityGrade === "A" || log.qualityGrade === "B" || log.qualityGrade === "C" || log.qualityGrade === "reject"
+        ? log.qualityGrade
+        : QUALITY_DEFAULT,
+    pestIncidentLevel:
+      log.pestIncidentLevel === "none" ||
+      log.pestIncidentLevel === "minor" ||
+      log.pestIncidentLevel === "moderate" ||
+      log.pestIncidentLevel === "severe"
+        ? log.pestIncidentLevel
+        : PEST_DEFAULT,
+    weatherImpact:
+      log.weatherImpact === "none" ||
+      log.weatherImpact === "heat" ||
+      log.weatherImpact === "rain" ||
+      log.weatherImpact === "wind" ||
+      log.weatherImpact === "cold" ||
+      log.weatherImpact === "mixed"
+        ? log.weatherImpact
+        : WEATHER_DEFAULT,
+  };
+}
+
+export function summarizeOutcomeLogs(logs: HarvestLog[]): OutcomeSummary {
+  const summary: OutcomeSummary = {
+    qualityCounts: { A: 0, B: 0, C: 0, reject: 0 },
+    pestCounts: { none: 0, minor: 0, moderate: 0, severe: 0 },
+    weatherImpactCounts: { none: 0, heat: 0, rain: 0, wind: 0, cold: 0, mixed: 0 },
+  };
+
+  for (const raw of logs) {
+    const log = normalizeHarvestLog(raw);
+    summary.qualityCounts[log.qualityGrade!] += 1;
+    summary.pestCounts[log.pestIncidentLevel!] += 1;
+    summary.weatherImpactCounts[log.weatherImpact!] += 1;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## Summary
- extend harvest outcome model with `qualityGrade`, `pestIncidentLevel`, and `weatherImpact`
- add normalization + summary utility for outcome logs with backward-compatible defaults for legacy records
- update farm management context to normalize enriched harvest logs on read/write
- upgrade harvest log UI to capture enriched outcome attributes and show quality/pest/weather distribution summaries
- update farm data transfer harvest CSV export/import normalization to include enriched outcome fields
- add tests for default migration behavior and summary aggregation

## Testing
- `bun run lint`
- `bun test`

Closes #23
