### PR TITLE
Implement #24 external data adapters and integration layer

### DIFF
--- a/docs/plans/2026-02-18-external-data-adapter-assumptions.md
+++ b/docs/plans/2026-02-18-external-data-adapter-assumptions.md
@@ -1,0 +1,25 @@
+# External Data Adapter Assumptions
+
+Date: 2026-02-18
+Issue: #24
+Status: Implementation notes
+
+## Security Assumptions
+
+- External adapters should avoid embedding long-lived credentials in browser-visible code.
+- Provider keys/tokens (when real providers are introduced) must be stored server-side only.
+- Adapter responses should be normalized before UI usage; no direct UI dependency on provider-specific payload fields.
+- Errors from providers should be sanitized before returning to clients.
+
+## Rate-Limit Assumptions
+
+- UI reads should go through a single integration overview endpoint to reduce fan-out.
+- Adapters are expected to be polled at bounded intervals; avoid per-render fetch loops.
+- Provider failures should degrade gracefully to cached/mock/null payloads without blocking local planning features.
+- Future production providers should support per-source timeout and retry budgets to avoid cascading latency.
+
+## Current Scope
+
+- Implemented mock adapters for climate, market price, and sensor snapshots.
+- Added normalized `freshness` + `confidence` metadata envelope at adapter boundary.
+- Added orchestration service and API endpoint `/api/integration/overview`.

--- a/src/app/api/integration/overview/route.ts
+++ b/src/app/api/integration/overview/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getIntegrationOverview } from "@/lib/integration/service";
+
+export async function GET() {
+  try {
+    const data = await getIntegrationOverview();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Integration overview error:", error);
+    return NextResponse.json({ error: "無法取得整合資料總覽" }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { PlantingSuggestionsCard } from "@/components/dashboard/planting-suggest
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import { HarvestCountdown } from "@/components/dashboard/harvest-countdown";
 import { WeatherWidget } from "@/components/dashboard/weather-widget";
+import { IntegrationStatus } from "@/components/dashboard/integration-status";
 import { prioritizeWeeklyTasks } from "@/lib/utils/task-prioritizer";
 import { forecastWorkload } from "@/lib/utils/workload-forecast";
 import { Sprout, Map, CalendarDays, CheckCircle2, Check } from "lucide-react";
@@ -235,6 +236,7 @@ export default function HomePage() {
 
       {/* 即時天氣 */}
       <WeatherWidget />
+      <IntegrationStatus />
     </div>
   );
 }

--- a/src/components/dashboard/integration-status.tsx
+++ b/src/components/dashboard/integration-status.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+interface Envelope {
+  source: string;
+  freshness: "fresh" | "stale" | "expired";
+  confidence: {
+    score: number;
+    level: "low" | "medium" | "high";
+  };
+}
+
+interface IntegrationOverview {
+  climate: Envelope | null;
+  market: Envelope | null;
+  sensor: Envelope | null;
+  errors: string[];
+}
+
+function rowLabel(key: "climate" | "market" | "sensor") {
+  if (key === "climate") return "氣候資料";
+  if (key === "market") return "行情資料";
+  return "感測資料";
+}
+
+export function IntegrationStatus() {
+  const [overview, setOverview] = useState<IntegrationOverview | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchOverview = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/integration/overview");
+      if (!res.ok) throw new Error("fetch failed");
+      const data = (await res.json()) as IntegrationOverview;
+      setOverview(data);
+    } catch {
+      setOverview({
+        climate: null,
+        market: null,
+        sensor: null,
+        errors: ["整合資料來源暫時不可用"],
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchOverview();
+  }, [fetchOverview]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">外部資料整合狀態</CardTitle>
+          <Button variant="ghost" size="sm" onClick={fetchOverview} disabled={loading}>
+            <RefreshCw className={`size-3 mr-1 ${loading ? "animate-spin" : ""}`} />
+            更新
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {(["climate", "market", "sensor"] as const).map((key) => {
+          const item = overview?.[key] ?? null;
+          return (
+            <div key={key} className="rounded border p-2 text-sm">
+              <p className="font-medium">{rowLabel(key)}</p>
+              {item ? (
+                <p className="text-muted-foreground">
+                  {item.source} ・ 新鮮度 {item.freshness} ・ 信心 {item.confidence.score}/100 ({item.confidence.level})
+                </p>
+              ) : (
+                <p className="text-muted-foreground">目前無可用資料</p>
+              )}
+            </div>
+          );
+        })}
+        {overview?.errors?.length ? <p className="text-xs text-muted-foreground">{overview.errors.join("；")}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/integration/normalize.test.ts
+++ b/src/lib/integration/normalize.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAdapterEnvelope } from "@/lib/integration/normalize";
+
+describe("normalizeAdapterEnvelope", () => {
+  it("normalizes confidence boundaries and freshness", () => {
+    const envelope = normalizeAdapterEnvelope({
+      source: "mock",
+      fetchedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      confidenceScore: 120,
+      payload: { ok: true },
+    });
+
+    expect(envelope.confidence.score).toBe(100);
+    expect(envelope.confidence.level).toBe("high");
+    expect(envelope.freshness).toBe("fresh");
+  });
+
+  it("marks expired freshness for old timestamps", () => {
+    const envelope = normalizeAdapterEnvelope({
+      source: "mock",
+      fetchedAt: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
+      confidenceScore: 30,
+      payload: { ok: true },
+    });
+    expect(envelope.freshness).toBe("expired");
+    expect(envelope.confidence.level).toBe("low");
+  });
+});

--- a/src/lib/integration/normalize.ts
+++ b/src/lib/integration/normalize.ts
@@ -1,0 +1,36 @@
+import type { AdapterEnvelope, ConfidenceLevel, FreshnessLabel } from "@/lib/integration/types";
+
+function computeFreshness(fetchedAt: string, now = new Date()): FreshnessLabel {
+  const parsed = new Date(fetchedAt);
+  const minutes = Number.isNaN(parsed.getTime()) ? 9999 : Math.max(0, Math.round((now.getTime() - parsed.getTime()) / 60000));
+  if (minutes <= 60) return "fresh";
+  if (minutes <= 240) return "stale";
+  return "expired";
+}
+
+function toConfidenceLevel(score: number): ConfidenceLevel {
+  if (score >= 75) return "high";
+  if (score >= 45) return "medium";
+  return "low";
+}
+
+export function normalizeAdapterEnvelope<TPayload>(input: {
+  source: string;
+  fetchedAt: string;
+  payload: TPayload;
+  confidenceScore: number;
+}): AdapterEnvelope<TPayload> {
+  const normalizedScore = Math.max(0, Math.min(100, Math.round(input.confidenceScore)));
+  const parsed = new Date(input.fetchedAt);
+  const fetchedAt = Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+  return {
+    source: input.source,
+    fetchedAt,
+    freshness: computeFreshness(input.fetchedAt),
+    confidence: {
+      score: normalizedScore,
+      level: toConfidenceLevel(normalizedScore),
+    },
+    payload: input.payload,
+  };
+}

--- a/src/lib/integration/providers/mock-climate-provider.ts
+++ b/src/lib/integration/providers/mock-climate-provider.ts
@@ -1,0 +1,19 @@
+import { normalizeAdapterEnvelope } from "@/lib/integration/normalize";
+import type { ClimateProvider } from "@/lib/integration/types";
+
+export const mockClimateProvider: ClimateProvider = {
+  source: "mock-climate-open-data",
+  async fetchClimate() {
+    return normalizeAdapterEnvelope({
+      source: "mock-climate-open-data",
+      fetchedAt: new Date().toISOString(),
+      confidenceScore: 68,
+      payload: {
+        period: "2026-Q1",
+        seasonalRainfallMm: 420,
+        heatStressIndex: 0.58,
+        note: "春季降雨偏多，注意排水與病害風險。",
+      },
+    });
+  },
+};

--- a/src/lib/integration/providers/mock-market-price-provider.ts
+++ b/src/lib/integration/providers/mock-market-price-provider.ts
@@ -1,0 +1,19 @@
+import { normalizeAdapterEnvelope } from "@/lib/integration/normalize";
+import type { MarketPriceProvider } from "@/lib/integration/types";
+
+export const mockMarketPriceProvider: MarketPriceProvider = {
+  source: "mock-market-feed",
+  async fetchPrice() {
+    return normalizeAdapterEnvelope({
+      source: "mock-market-feed",
+      fetchedAt: new Date().toISOString(),
+      confidenceScore: 55,
+      payload: {
+        cropName: "番茄",
+        currencyUnit: "TWD/kg",
+        latestPrice: 52.4,
+        trend: "stable",
+      },
+    });
+  },
+};

--- a/src/lib/integration/providers/mock-sensor-provider.ts
+++ b/src/lib/integration/providers/mock-sensor-provider.ts
@@ -1,0 +1,20 @@
+import { normalizeAdapterEnvelope } from "@/lib/integration/normalize";
+import type { SensorSnapshotProvider } from "@/lib/integration/types";
+
+export const mockSensorProvider: SensorSnapshotProvider = {
+  source: "mock-sensor-adapter",
+  async fetchSensorSnapshot() {
+    return normalizeAdapterEnvelope({
+      source: "mock-sensor-adapter",
+      fetchedAt: new Date().toISOString(),
+      confidenceScore: 72,
+      payload: {
+        deviceId: "sensor-demo-1",
+        soilMoisturePct: 41,
+        soilTemperatureC: 24.6,
+        batteryPct: 86,
+        connectivity: "online",
+      },
+    });
+  },
+};

--- a/src/lib/integration/service.test.ts
+++ b/src/lib/integration/service.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getIntegrationOverview } from "@/lib/integration/service";
+
+describe("getIntegrationOverview", () => {
+  it("returns normalized envelopes for all adapter categories", async () => {
+    const result = await getIntegrationOverview();
+
+    expect(result.climate?.source).toBeTruthy();
+    expect(result.market?.source).toBeTruthy();
+    expect(result.sensor?.source).toBeTruthy();
+    expect(result.climate?.confidence.score).toBeGreaterThanOrEqual(0);
+    expect(result.market?.freshness).toBeTruthy();
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/lib/integration/service.ts
+++ b/src/lib/integration/service.ts
@@ -1,0 +1,39 @@
+import { mockClimateProvider } from "@/lib/integration/providers/mock-climate-provider";
+import { mockMarketPriceProvider } from "@/lib/integration/providers/mock-market-price-provider";
+import { mockSensorProvider } from "@/lib/integration/providers/mock-sensor-provider";
+import type { AdapterEnvelope, ClimatePayload, MarketPricePayload, SensorSnapshotPayload } from "@/lib/integration/types";
+
+export interface IntegrationOverview {
+  fetchedAt: string;
+  climate: AdapterEnvelope<ClimatePayload> | null;
+  market: AdapterEnvelope<MarketPricePayload> | null;
+  sensor: AdapterEnvelope<SensorSnapshotPayload> | null;
+  errors: string[];
+}
+
+export async function getIntegrationOverview(): Promise<IntegrationOverview> {
+  const errors: string[] = [];
+
+  const [climate, market, sensor] = await Promise.all([
+    mockClimateProvider.fetchClimate().catch((error) => {
+      errors.push(`climate:${error instanceof Error ? error.message : "unknown"}`);
+      return null;
+    }),
+    mockMarketPriceProvider.fetchPrice().catch((error) => {
+      errors.push(`market:${error instanceof Error ? error.message : "unknown"}`);
+      return null;
+    }),
+    mockSensorProvider.fetchSensorSnapshot().catch((error) => {
+      errors.push(`sensor:${error instanceof Error ? error.message : "unknown"}`);
+      return null;
+    }),
+  ]);
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    climate,
+    market,
+    sensor,
+    errors,
+  };
+}

--- a/src/lib/integration/types.ts
+++ b/src/lib/integration/types.ts
@@ -1,0 +1,50 @@
+export type FreshnessLabel = "fresh" | "stale" | "expired";
+export type ConfidenceLevel = "low" | "medium" | "high";
+
+export interface AdapterEnvelope<TPayload> {
+  source: string;
+  fetchedAt: string;
+  freshness: FreshnessLabel;
+  confidence: {
+    score: number;
+    level: ConfidenceLevel;
+  };
+  payload: TPayload;
+}
+
+export interface ClimatePayload {
+  period: string;
+  seasonalRainfallMm: number;
+  heatStressIndex: number;
+  note: string;
+}
+
+export interface MarketPricePayload {
+  cropName: string;
+  currencyUnit: string;
+  latestPrice: number;
+  trend: "up" | "down" | "stable";
+}
+
+export interface SensorSnapshotPayload {
+  deviceId: string;
+  soilMoisturePct: number;
+  soilTemperatureC: number;
+  batteryPct: number;
+  connectivity: "online" | "offline";
+}
+
+export interface ClimateProvider {
+  source: string;
+  fetchClimate: () => Promise<AdapterEnvelope<ClimatePayload>>;
+}
+
+export interface MarketPriceProvider {
+  source: string;
+  fetchPrice: () => Promise<AdapterEnvelope<MarketPricePayload>>;
+}
+
+export interface SensorSnapshotProvider {
+  source: string;
+  fetchSensorSnapshot: () => Promise<AdapterEnvelope<SensorSnapshotPayload>>;
+}


### PR DESCRIPTION
## Summary
- add external integration adapter contracts for climate, market price, and sensor snapshots
- add adapter-boundary normalization envelope with standardized freshness/confidence metadata
- implement mock providers for all three adapter categories
- add integration orchestration service and API exposure at `/api/integration/overview`
- add dashboard integration status card that consumes normalized integration outputs (provider-agnostic UI)
- document security and rate-limit assumptions in `docs/plans/2026-02-18-external-data-adapter-assumptions.md`
- add unit tests for normalization consistency and integration service behavior

## Testing
- `bun run lint`
- `bun test`

Closes #24
