### PR TITLE
feat: versioned planner backup with weekly/monthly schedule

### DIFF
--- a/src/app/farm-management/page.tsx
+++ b/src/app/farm-management/page.tsx
@@ -9,6 +9,7 @@ import { SoilNotesTab } from "@/components/farm-management/soil-notes-tab";
 import { WeatherTab } from "@/components/farm-management/weather-tab";
 import { RotationTab } from "@/components/farm-management/rotation-tab";
 import { DataTransferPanel } from "@/components/farm-management/data-transfer-panel";
+import { BackupSettingsPanel } from "@/components/farm-management/backup-settings-panel";
 
 function FarmManagementContent() {
   const searchParams = useSearchParams();
@@ -41,6 +42,7 @@ export default function FarmManagementPage() {
       </div>
 
       <Suspense fallback={<div className="text-center py-8 text-muted-foreground">載入中...</div>}>
+        <BackupSettingsPanel />
         <DataTransferPanel />
         <FarmManagementContent />
       </Suspense>

--- a/src/components/farm-management/backup-settings-panel.tsx
+++ b/src/components/farm-management/backup-settings-panel.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { format } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  createPlannerBackup,
+  normalizePlannerBackupSettings,
+  readPlannerBackupSettings,
+  readPlannerBackupSnapshots,
+  restorePlannerBackup,
+  writePlannerBackupSettings,
+  type PlannerBackupSchedule,
+  type PlannerBackupSettings,
+  type PlannerBackupSnapshot,
+} from "@/lib/store/planner-backup";
+
+function formatTimestamp(value?: string) {
+  if (!value) return "尚未執行";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "尚未執行";
+  return format(date, "yyyy/MM/dd HH:mm");
+}
+
+export function BackupSettingsPanel() {
+  const [settings, setSettings] = useState<PlannerBackupSettings>(() => {
+    if (typeof window === "undefined") return normalizePlannerBackupSettings(null);
+    return readPlannerBackupSettings(window.localStorage);
+  });
+  const [snapshots, setSnapshots] = useState<PlannerBackupSnapshot[]>(() => {
+    if (typeof window === "undefined") return [];
+    return readPlannerBackupSnapshots(window.localStorage);
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    const nextSettings = readPlannerBackupSettings(window.localStorage);
+    const nextSnapshots = readPlannerBackupSnapshots(window.localStorage);
+    setSettings(nextSettings);
+    setSnapshots(nextSnapshots);
+  }, []);
+
+  const updateSchedule = (schedule: PlannerBackupSchedule) => {
+    const next = writePlannerBackupSettings(window.localStorage, { schedule });
+    setSettings(next);
+    setStatus("已更新自動備份頻率。");
+  };
+
+  const updateRetention = (input: string) => {
+    const retentionCount = Number(input);
+    if (!Number.isFinite(retentionCount)) return;
+    const next = writePlannerBackupSettings(window.localStorage, { retentionCount });
+    setSettings(next);
+    setStatus("已更新備份保留份數。");
+    refresh();
+  };
+
+  const handleManualBackup = () => {
+    const snapshot = createPlannerBackup(window.localStorage, { reason: "manual" });
+    setStatus(`已建立備份：${formatTimestamp(snapshot.createdAt)}`);
+    refresh();
+  };
+
+  const handleRestore = (snapshotId: string) => {
+    const confirmed = window.confirm("還原後將以備份內容覆蓋目前資料，確定繼續？");
+    if (!confirmed) return;
+    const restored = restorePlannerBackup(window.localStorage, snapshotId);
+    if (!restored) {
+      setStatus("找不到指定備份，請重新整理後再試。");
+      return;
+    }
+    setStatus("已還原備份，正在重新載入資料。");
+    window.setTimeout(() => window.location.reload(), 300);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">庭園規劃備份設定</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">自動備份頻率</p>
+            <Select value={settings.schedule} onValueChange={(value) => updateSchedule(value as PlannerBackupSchedule)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="off">關閉</SelectItem>
+                <SelectItem value="weekly">每週</SelectItem>
+                <SelectItem value="monthly">每月</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium">保留備份份數（1-32）</p>
+            <Input
+              type="number"
+              min={1}
+              max={32}
+              value={settings.retentionCount}
+              onChange={(event) => updateRetention(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button size="sm" variant="outline" onClick={handleManualBackup}>
+            立即備份
+          </Button>
+          <span className="text-xs text-muted-foreground">最近自動備份：{formatTimestamp(settings.lastAutoBackupAt)}</span>
+        </div>
+
+        <div className="space-y-2 rounded-md border p-3">
+          <p className="text-sm font-medium">備份清單（最新在前）</p>
+          {snapshots.length === 0 ? (
+            <p className="text-sm text-muted-foreground">尚無備份。</p>
+          ) : (
+            <div className="space-y-2">
+              {snapshots.slice(0, 8).map((snapshot) => (
+                <div key={snapshot.id} className="flex items-center justify-between rounded-md border px-3 py-2">
+                  <div>
+                    <p className="text-sm">{formatTimestamp(snapshot.createdAt)}</p>
+                    <p className="text-xs text-muted-foreground">來源：{snapshot.reason}</p>
+                  </div>
+                  <Button size="sm" variant="secondary" onClick={() => handleRestore(snapshot.id)}>
+                    還原
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {status && <p className="text-xs text-muted-foreground">{status}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/store/app-provider.tsx
+++ b/src/lib/store/app-provider.tsx
@@ -5,13 +5,17 @@ import { FieldsProvider } from "./fields-context";
 import { TasksProvider } from "./tasks-context";
 import { CustomCropsProvider } from "./custom-crops-context";
 import { FarmManagementProvider } from "./farm-management-context";
+import { PlannerBackupRuntime } from "./planner-backup-runtime";
 
 export function AppProvider({ children }: { children: ReactNode }) {
   return (
     <CustomCropsProvider>
       <FieldsProvider>
         <TasksProvider>
-          <FarmManagementProvider>{children}</FarmManagementProvider>
+          <FarmManagementProvider>
+            <PlannerBackupRuntime />
+            {children}
+          </FarmManagementProvider>
         </TasksProvider>
       </FieldsProvider>
     </CustomCropsProvider>

--- a/src/lib/store/planner-backup-runtime.tsx
+++ b/src/lib/store/planner-backup-runtime.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useCustomCrops } from "@/lib/store/custom-crops-context";
+import { useFarmManagement } from "@/lib/store/farm-management-context";
+import { useFields } from "@/lib/store/fields-context";
+import { runScheduledPlannerBackup } from "@/lib/store/planner-backup";
+import { useTasks } from "@/lib/store/tasks-context";
+
+const BACKUP_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export function PlannerBackupRuntime() {
+  const { isLoaded: fieldsLoaded } = useFields();
+  const { isLoaded: tasksLoaded } = useTasks();
+  const { isLoaded: cropsLoaded } = useCustomCrops();
+  const { isLoaded: farmLoaded } = useFarmManagement();
+  const didBootstrap = useRef(false);
+
+  const allLoaded = fieldsLoaded && tasksLoaded && cropsLoaded && farmLoaded;
+
+  useEffect(() => {
+    if (!allLoaded || didBootstrap.current) return;
+    didBootstrap.current = true;
+    runScheduledPlannerBackup(window.localStorage);
+  }, [allLoaded]);
+
+  useEffect(() => {
+    if (!allLoaded) return;
+    const timer = window.setInterval(() => {
+      runScheduledPlannerBackup(window.localStorage);
+    }, BACKUP_CHECK_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [allLoaded]);
+
+  return null;
+}

--- a/src/lib/store/planner-backup.test.ts
+++ b/src/lib/store/planner-backup.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLANNER_BACKUP_DATA_KEYS,
+  PLANNER_BACKUP_SETTINGS_KEY,
+  PLANNER_BACKUP_SNAPSHOTS_KEY,
+  createPlannerBackup,
+  isPlannerBackupDue,
+  normalizePlannerBackupSettings,
+  readPlannerBackupSettings,
+  readPlannerBackupSnapshots,
+  restorePlannerBackup,
+  runScheduledPlannerBackup,
+  writePlannerBackupSettings,
+  type PlannerBackupSettings,
+  type StorageLike,
+} from "@/lib/store/planner-backup";
+
+class MemoryStorage implements StorageLike {
+  private readonly map = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.map.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.map.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.map.delete(key);
+  }
+}
+
+describe("planner backup settings", () => {
+  it("normalizes invalid settings with defaults", () => {
+    const normalized = normalizePlannerBackupSettings({ schedule: "invalid", retentionCount: -5 });
+    expect(normalized.schedule).toBe("off");
+    expect(normalized.retentionCount).toBe(1);
+  });
+
+  it("writes and reads settings with schema migration", () => {
+    const storage = new MemoryStorage();
+    writePlannerBackupSettings(storage, { schedule: "weekly", retentionCount: 12, lastAutoBackupAt: "2026-02-01" });
+    const settings = readPlannerBackupSettings(storage);
+    expect(settings.schedule).toBe("weekly");
+    expect(settings.retentionCount).toBe(12);
+    expect(settings.lastAutoBackupAt).toBe("2026-02-01T00:00:00.000Z");
+  });
+});
+
+describe("planner backup snapshots", () => {
+  it("keeps retention count when creating snapshots", () => {
+    const storage = new MemoryStorage();
+    writePlannerBackupSettings(storage, { schedule: "off", retentionCount: 2 });
+    storage.setItem("hualien-planner-events", JSON.stringify([{ id: "evt-1" }]));
+
+    createPlannerBackup(storage, { now: new Date("2026-02-01T00:00:00.000Z") });
+    createPlannerBackup(storage, { now: new Date("2026-02-02T00:00:00.000Z") });
+    createPlannerBackup(storage, { now: new Date("2026-02-03T00:00:00.000Z") });
+
+    const snapshots = readPlannerBackupSnapshots(storage);
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0].createdAt).toBe("2026-02-03T00:00:00.000Z");
+  });
+
+  it("restores tracked localStorage keys from selected snapshot", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("hualien-planner-events", JSON.stringify([{ id: "before" }]));
+    const snapshot = createPlannerBackup(storage, { now: new Date("2026-02-04T00:00:00.000Z") });
+
+    storage.setItem("hualien-planner-events", JSON.stringify([{ id: "after" }]));
+    storage.setItem("hualien-tasks", JSON.stringify([{ id: "task-1" }]));
+
+    const restored = restorePlannerBackup(storage, snapshot.id);
+    expect(restored).toBe(true);
+    expect(storage.getItem("hualien-planner-events")).toBe(JSON.stringify([{ id: "before" }]));
+    expect(storage.getItem("hualien-tasks")).toBe(null);
+  });
+
+  it("reads legacy snapshot payload shape for compatibility", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      PLANNER_BACKUP_SNAPSHOTS_KEY,
+      JSON.stringify([
+        {
+          id: "legacy-1",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          data: {
+            "hualien-planner-events": "[]",
+          },
+        },
+      ])
+    );
+
+    const snapshots = readPlannerBackupSnapshots(storage);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].payloadByKey["hualien-planner-events"]).toBe("[]");
+  });
+});
+
+describe("planner backup schedule", () => {
+  const weeklySettings: PlannerBackupSettings = {
+    schemaVersion: 1,
+    schedule: "weekly",
+    retentionCount: 8,
+    lastAutoBackupAt: "2026-02-01T00:00:00.000Z",
+  };
+
+  it("marks weekly schedule due only after 7 days", () => {
+    expect(isPlannerBackupDue(weeklySettings, new Date("2026-02-06T23:59:59.000Z"))).toBe(false);
+    expect(isPlannerBackupDue(weeklySettings, new Date("2026-02-08T00:00:00.000Z"))).toBe(true);
+  });
+
+  it("runs scheduled backup and updates last auto timestamp", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      PLANNER_BACKUP_SETTINGS_KEY,
+      JSON.stringify({
+        schedule: "monthly",
+        retentionCount: 8,
+        lastAutoBackupAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+    storage.setItem("hualien-planner-events", "[]");
+
+    const snapshot = runScheduledPlannerBackup(storage, new Date("2026-02-02T00:00:00.000Z"));
+    expect(snapshot?.reason).toBe("auto-monthly");
+
+    const updatedSettings = readPlannerBackupSettings(storage);
+    expect(updatedSettings.lastAutoBackupAt).toBe("2026-02-02T00:00:00.000Z");
+  });
+
+  it("captures all tracked keys in payload", () => {
+    const storage = new MemoryStorage();
+    PLANNER_BACKUP_DATA_KEYS.forEach((key, index) => {
+      storage.setItem(key, JSON.stringify({ index }));
+    });
+
+    const snapshot = createPlannerBackup(storage, { now: new Date("2026-02-10T00:00:00.000Z") });
+    expect(Object.keys(snapshot.payloadByKey).sort()).toEqual([...PLANNER_BACKUP_DATA_KEYS].sort());
+  });
+});

--- a/src/lib/store/planner-backup.ts
+++ b/src/lib/store/planner-backup.ts
@@ -1,0 +1,209 @@
+export const PLANNER_BACKUP_SETTINGS_KEY = "hualien-planner-backup-settings";
+export const PLANNER_BACKUP_SNAPSHOTS_KEY = "hualien-planner-backup-snapshots";
+export const PLANNER_BACKUP_SCHEMA_VERSION = 1;
+
+export const PLANNER_BACKUP_DATA_KEYS = [
+  "hualien-planner-events",
+  "hualien-show-harvested",
+  "hualien-tasks",
+  "hualien-custom-crops",
+  "hualien-crop-templates",
+  "hualien-harvest-logs",
+  "hualien-finance",
+  "hualien-soil-notes",
+  "hualien-soil-profiles",
+  "hualien-soil-amendments",
+  "hualien-weather-logs",
+] as const;
+
+export type PlannerBackupSchedule = "off" | "weekly" | "monthly";
+export type PlannerBackupReason = "manual" | "auto-weekly" | "auto-monthly";
+
+export interface PlannerBackupSettings {
+  schemaVersion: number;
+  schedule: PlannerBackupSchedule;
+  retentionCount: number;
+  lastAutoBackupAt?: string;
+}
+
+export interface PlannerBackupSnapshot {
+  id: string;
+  schemaVersion: number;
+  createdAt: string;
+  reason: PlannerBackupReason;
+  payloadByKey: Record<string, string | null>;
+}
+
+export interface StorageLike {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+const DEFAULT_SETTINGS: PlannerBackupSettings = {
+  schemaVersion: PLANNER_BACKUP_SCHEMA_VERSION,
+  schedule: "off",
+  retentionCount: 8,
+};
+
+function clampRetentionCount(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_SETTINGS.retentionCount;
+  return Math.max(1, Math.min(32, Math.round(parsed)));
+}
+
+function parseJson<T>(input: string | null): T | null {
+  if (!input) return null;
+  try {
+    return JSON.parse(input) as T;
+  } catch {
+    return null;
+  }
+}
+
+function parseIsoDate(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString();
+}
+
+export function normalizePlannerBackupSettings(input: unknown): PlannerBackupSettings {
+  if (!input || typeof input !== "object") return { ...DEFAULT_SETTINGS };
+  const raw = input as Record<string, unknown>;
+
+  const schedule: PlannerBackupSchedule =
+    raw.schedule === "weekly" || raw.schedule === "monthly" || raw.schedule === "off" ? raw.schedule : "off";
+
+  return {
+    schemaVersion: PLANNER_BACKUP_SCHEMA_VERSION,
+    schedule,
+    retentionCount: clampRetentionCount(raw.retentionCount),
+    lastAutoBackupAt: parseIsoDate(raw.lastAutoBackupAt),
+  };
+}
+
+function normalizeSnapshot(input: unknown): PlannerBackupSnapshot | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = input as Record<string, unknown>;
+  const id = typeof raw.id === "string" && raw.id.trim().length > 0 ? raw.id : undefined;
+  const createdAt = parseIsoDate(raw.createdAt);
+  const reason: PlannerBackupReason =
+    raw.reason === "auto-weekly" || raw.reason === "auto-monthly" || raw.reason === "manual" ? raw.reason : "manual";
+  const payloadRaw = (raw.payloadByKey ?? raw.data) as unknown;
+
+  if (!id || !createdAt || !payloadRaw || typeof payloadRaw !== "object") return null;
+
+  const payloadByKey: Record<string, string | null> = {};
+  for (const [key, value] of Object.entries(payloadRaw as Record<string, unknown>)) {
+    if (typeof value === "string" || value === null) {
+      payloadByKey[key] = value;
+    }
+  }
+
+  return {
+    id,
+    schemaVersion: PLANNER_BACKUP_SCHEMA_VERSION,
+    createdAt,
+    reason,
+    payloadByKey,
+  };
+}
+
+function buildSnapshotPayload(storage: StorageLike): Record<string, string | null> {
+  const payload: Record<string, string | null> = {};
+  for (const key of PLANNER_BACKUP_DATA_KEYS) {
+    payload[key] = storage.getItem(key);
+  }
+  return payload;
+}
+
+export function readPlannerBackupSettings(storage: StorageLike): PlannerBackupSettings {
+  return normalizePlannerBackupSettings(parseJson(storage.getItem(PLANNER_BACKUP_SETTINGS_KEY)));
+}
+
+export function writePlannerBackupSettings(storage: StorageLike, updates: Partial<PlannerBackupSettings>): PlannerBackupSettings {
+  const current = readPlannerBackupSettings(storage);
+  const next = normalizePlannerBackupSettings({ ...current, ...updates });
+  storage.setItem(PLANNER_BACKUP_SETTINGS_KEY, JSON.stringify(next));
+  return next;
+}
+
+export function readPlannerBackupSnapshots(storage: StorageLike): PlannerBackupSnapshot[] {
+  const parsed = parseJson<unknown[]>(storage.getItem(PLANNER_BACKUP_SNAPSHOTS_KEY));
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .map((item) => normalizeSnapshot(item))
+    .filter((item): item is PlannerBackupSnapshot => item !== null)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+export function createPlannerBackup(
+  storage: StorageLike,
+  options?: { reason?: PlannerBackupReason; now?: Date; settings?: PlannerBackupSettings }
+): PlannerBackupSnapshot {
+  const settings = options?.settings ?? readPlannerBackupSettings(storage);
+  const now = options?.now ?? new Date();
+  const createdAt = now.toISOString();
+
+  const snapshot: PlannerBackupSnapshot = {
+    id: `backup-${now.getTime()}-${Math.random().toString(36).slice(2, 8)}`,
+    schemaVersion: PLANNER_BACKUP_SCHEMA_VERSION,
+    createdAt,
+    reason: options?.reason ?? "manual",
+    payloadByKey: buildSnapshotPayload(storage),
+  };
+
+  const snapshots = readPlannerBackupSnapshots(storage);
+  const retained = [snapshot, ...snapshots]
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .slice(0, settings.retentionCount);
+  storage.setItem(PLANNER_BACKUP_SNAPSHOTS_KEY, JSON.stringify(retained));
+
+  if (snapshot.reason === "auto-weekly" || snapshot.reason === "auto-monthly") {
+    writePlannerBackupSettings(storage, { ...settings, lastAutoBackupAt: snapshot.createdAt });
+  }
+
+  return snapshot;
+}
+
+export function restorePlannerBackup(storage: StorageLike, snapshotId: string): boolean {
+  const snapshot = readPlannerBackupSnapshots(storage).find((item) => item.id === snapshotId);
+  if (!snapshot) return false;
+
+  for (const key of PLANNER_BACKUP_DATA_KEYS) {
+    const value = snapshot.payloadByKey[key];
+    if (typeof value === "string") {
+      storage.setItem(key, value);
+    } else {
+      storage.removeItem(key);
+    }
+  }
+
+  return true;
+}
+
+export function isPlannerBackupDue(settings: PlannerBackupSettings, now: Date): boolean {
+  if (settings.schedule === "off") return false;
+  if (!settings.lastAutoBackupAt) return true;
+
+  const last = new Date(settings.lastAutoBackupAt);
+  if (Number.isNaN(last.getTime())) return true;
+
+  if (settings.schedule === "weekly") {
+    const diffMs = now.getTime() - last.getTime();
+    return diffMs >= 7 * 24 * 60 * 60 * 1000;
+  }
+
+  const nextMonthly = new Date(last);
+  nextMonthly.setMonth(nextMonthly.getMonth() + 1);
+  return now.getTime() >= nextMonthly.getTime();
+}
+
+export function runScheduledPlannerBackup(storage: StorageLike, now = new Date()): PlannerBackupSnapshot | null {
+  const settings = readPlannerBackupSettings(storage);
+  if (!isPlannerBackupDue(settings, now)) return null;
+
+  const reason: PlannerBackupReason = settings.schedule === "weekly" ? "auto-weekly" : "auto-monthly";
+  return createPlannerBackup(storage, { reason, now, settings });
+}


### PR DESCRIPTION
## Summary
- add versioned planner backup store with schema-aware normalization and legacy snapshot compatibility
- add weekly/monthly scheduled auto-backup runtime with retention policy
- add farm management backup settings panel for schedule, retention, manual backup, and restore
- cover backup logic with unit tests for due rules, retention, restore, and migration behavior

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #35
