### PR TITLE
feat: polygon region model for field planner

### DIFF
--- a/src/lib/planner/events.test.ts
+++ b/src/lib/planner/events.test.ts
@@ -156,4 +156,54 @@ describe("replayPlannerEvents", () => {
       sunHours: "lt4",
     });
   });
+
+  it("detects spatial conflict when polygon shape overlaps another region", () => {
+    const events: PlannerEvent[] = [
+      {
+        id: "1",
+        type: "field_created",
+        occurredAt: "2026-02-10T00:00:00.000Z",
+        fieldId: "field-1",
+        payload: { id: "field-1", name: "A 區", dimensions: { width: 5, height: 4 } },
+      },
+      {
+        id: "2",
+        type: "crop_planted",
+        occurredAt: "2026-02-11T00:00:00.000Z",
+        fieldId: "field-1",
+        cropId: "pc-1",
+        payload: plantedCrop({
+          id: "pc-1",
+          plantedDate: "2026-02-11T00:00:00.000Z",
+          position: { x: 0, y: 0 },
+          size: { width: 60, height: 40 },
+          shape: {
+            kind: "polygon",
+            points: [
+              { x: 0, y: 0 },
+              { x: 80, y: 0 },
+              { x: 80, y: 80 },
+              { x: 0, y: 80 },
+            ],
+          },
+        }),
+      },
+      {
+        id: "3",
+        type: "crop_planted",
+        occurredAt: "2026-02-11T00:00:00.000Z",
+        fieldId: "field-1",
+        cropId: "pc-2",
+        payload: plantedCrop({
+          id: "pc-2",
+          plantedDate: "2026-02-11T00:00:00.000Z",
+          position: { x: 40, y: 20 },
+          size: { width: 40, height: 40 },
+        }),
+      },
+    ];
+
+    const conflicts = detectSpatialConflictsAt(events, "2026-02-12T00:00:00.000Z");
+    expect(conflicts.length).toBeGreaterThan(0);
+  });
 });

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -104,6 +104,18 @@ export interface CropStageProfile {
   pestRisk: "低" | "中" | "高";
 }
 
+export interface CropPoint {
+  x: number;
+  y: number;
+}
+
+export interface PolygonCropShape {
+  kind: "polygon";
+  points: CropPoint[];
+}
+
+export type PlantedCropShape = PolygonCropShape;
+
 export interface PlantedCrop {
   id: string;
   cropId: string;
@@ -113,6 +125,7 @@ export interface PlantedCrop {
   status: "growing" | "harvested" | "removed";
   position: { x: number; y: number };
   size: { width: number; height: number };
+  shape?: PlantedCropShape;
   customGrowthDays?: number;
   notes?: string;
 }

--- a/src/lib/utils/crop-shape.test.ts
+++ b/src/lib/utils/crop-shape.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getCropPolygon, polygonsOverlap, toTrapezoidPoints } from "@/lib/utils/crop-shape";
+import type { PlantedCrop } from "@/lib/types";
+
+function planted(overrides?: Partial<PlantedCrop>): PlantedCrop {
+  return {
+    id: "pc-1",
+    cropId: "crop-1",
+    fieldId: "field-1",
+    plantedDate: "2026-02-01T00:00:00.000Z",
+    status: "growing",
+    position: { x: 10, y: 10 },
+    size: { width: 40, height: 30 },
+    ...overrides,
+  };
+}
+
+describe("crop-shape helpers", () => {
+  it("converts legacy rectangle crop to polygon points", () => {
+    const points = getCropPolygon(planted());
+    expect(points).toHaveLength(4);
+    expect(points[0]).toEqual({ x: 10, y: 10 });
+    expect(points[2]).toEqual({ x: 50, y: 40 });
+  });
+
+  it("detects overlap between polygon regions", () => {
+    const first = getCropPolygon(planted());
+    const second = getCropPolygon(planted({ position: { x: 35, y: 25 }, size: { width: 30, height: 25 } }));
+    const third = getCropPolygon(planted({ position: { x: 100, y: 100 }, size: { width: 20, height: 20 } }));
+
+    expect(polygonsOverlap(first, second)).toBe(true);
+    expect(polygonsOverlap(first, third)).toBe(false);
+  });
+
+  it("creates trapezoid points for shape conversion", () => {
+    const points = toTrapezoidPoints(planted());
+    expect(points).toHaveLength(4);
+    expect(points[0].y).toBe(points[1].y);
+    expect(points[2].y).toBe(points[3].y);
+  });
+});

--- a/src/lib/utils/crop-shape.ts
+++ b/src/lib/utils/crop-shape.ts
@@ -1,0 +1,123 @@
+import type { CropPoint, PlantedCrop } from "@/lib/types";
+
+function pointInPolygon(point: CropPoint, polygon: CropPoint[]) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+
+    const intersects = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi + Number.EPSILON) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function orientation(a: CropPoint, b: CropPoint, c: CropPoint) {
+  const value = (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y);
+  if (Math.abs(value) < Number.EPSILON) return 0;
+  return value > 0 ? 1 : 2;
+}
+
+function onSegment(a: CropPoint, b: CropPoint, c: CropPoint) {
+  return (
+    b.x <= Math.max(a.x, c.x) &&
+    b.x >= Math.min(a.x, c.x) &&
+    b.y <= Math.max(a.y, c.y) &&
+    b.y >= Math.min(a.y, c.y)
+  );
+}
+
+function segmentsIntersect(p1: CropPoint, q1: CropPoint, p2: CropPoint, q2: CropPoint) {
+  const o1 = orientation(p1, q1, p2);
+  const o2 = orientation(p1, q1, q2);
+  const o3 = orientation(p2, q2, p1);
+  const o4 = orientation(p2, q2, q1);
+
+  if (o1 !== o2 && o3 !== o4) return true;
+
+  if (o1 === 0 && onSegment(p1, p2, q1)) return true;
+  if (o2 === 0 && onSegment(p1, q2, q1)) return true;
+  if (o3 === 0 && onSegment(p2, p1, q2)) return true;
+  if (o4 === 0 && onSegment(p2, q1, q2)) return true;
+
+  return false;
+}
+
+export function getRectPoints(planted: Pick<PlantedCrop, "position" | "size">): CropPoint[] {
+  const x = planted.position.x;
+  const y = planted.position.y;
+  const w = planted.size.width;
+  const h = planted.size.height;
+  return [
+    { x, y },
+    { x: x + w, y },
+    { x: x + w, y: y + h },
+    { x, y: y + h },
+  ];
+}
+
+export function getCropPolygon(planted: PlantedCrop): CropPoint[] {
+  if (planted.shape?.kind === "polygon" && planted.shape.points.length >= 3) {
+    return planted.shape.points;
+  }
+  return getRectPoints(planted);
+}
+
+export function polygonBounds(points: CropPoint[]) {
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
+export function polygonsOverlap(first: CropPoint[], second: CropPoint[]) {
+  const firstBounds = polygonBounds(first);
+  const secondBounds = polygonBounds(second);
+  const boundsOverlap =
+    firstBounds.minX <= secondBounds.maxX &&
+    firstBounds.maxX >= secondBounds.minX &&
+    firstBounds.minY <= secondBounds.maxY &&
+    firstBounds.maxY >= secondBounds.minY;
+
+  if (!boundsOverlap) return false;
+
+  for (let i = 0; i < first.length; i += 1) {
+    const a1 = first[i];
+    const a2 = first[(i + 1) % first.length];
+    for (let j = 0; j < second.length; j += 1) {
+      const b1 = second[j];
+      const b2 = second[(j + 1) % second.length];
+      if (segmentsIntersect(a1, a2, b1, b2)) return true;
+    }
+  }
+
+  return pointInPolygon(first[0], second) || pointInPolygon(second[0], first);
+}
+
+export function toTrapezoidPoints(planted: Pick<PlantedCrop, "position" | "size">): CropPoint[] {
+  const { x, y } = planted.position;
+  const { width, height } = planted.size;
+  const inset = Math.max(width * 0.15, 6);
+  return [
+    { x: x + inset, y },
+    { x: x + width - inset, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height },
+  ];
+}
+
+export function translatePoints(points: CropPoint[], dx: number, dy: number): CropPoint[] {
+  return points.map((point) => ({ x: point.x + dx, y: point.y + dy }));
+}


### PR DESCRIPTION
## Summary
- add polygon shape support for planted regions while keeping rectangle compatibility
- add field planner editing support: convert selected region to trapezoid/polygon and adjust vertices directly on canvas
- update spatial conflict detection to use polygon overlap checks (with rectangle fallback)
- add geometry tests and planner event coverage for polygon overlap behavior

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #38
