### PR TITLE
feat: merge/split/reassign planner regions

### DIFF
--- a/src/lib/utils/region-edit.test.ts
+++ b/src/lib/utils/region-edit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { mergeCropRegions, splitCropRegion } from "@/lib/utils/region-edit";
+import type { PlantedCrop } from "@/lib/types";
+
+function crop(overrides?: Partial<PlantedCrop>): PlantedCrop {
+  return {
+    id: "pc-1",
+    cropId: "crop-1",
+    fieldId: "field-1",
+    plantedDate: "2026-02-01T00:00:00.000Z",
+    status: "growing",
+    position: { x: 10, y: 20 },
+    size: { width: 80, height: 40 },
+    ...overrides,
+  };
+}
+
+describe("region-edit", () => {
+  it("splits region vertically into two halves", () => {
+    const split = splitCropRegion(crop(), "vertical");
+    expect(split).not.toBeNull();
+    expect(split?.[0].width).toBe(40);
+    expect(split?.[1].x).toBe(50);
+  });
+
+  it("splits region horizontally into two halves", () => {
+    const split = splitCropRegion(crop(), "horizontal");
+    expect(split).not.toBeNull();
+    expect(split?.[0].height).toBe(20);
+    expect(split?.[1].y).toBe(40);
+  });
+
+  it("merges two regions into union bounding rectangle", () => {
+    const merged = mergeCropRegions(crop(), crop({ id: "pc-2", position: { x: 70, y: 30 }, size: { width: 40, height: 30 } }));
+    expect(merged).toEqual({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 40,
+    });
+  });
+});

--- a/src/lib/utils/region-edit.ts
+++ b/src/lib/utils/region-edit.ts
@@ -1,0 +1,59 @@
+import type { PlantedCrop } from "@/lib/types";
+import { getCropPolygon, polygonBounds } from "@/lib/utils/crop-shape";
+
+export type SplitDirection = "horizontal" | "vertical";
+
+export interface RegionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const MIN_SPLIT_SIZE = 20;
+
+export function getCropBoundingRect(crop: PlantedCrop): RegionRect {
+  const bounds = polygonBounds(getCropPolygon(crop));
+  return {
+    x: bounds.minX,
+    y: bounds.minY,
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+export function splitCropRegion(crop: PlantedCrop, direction: SplitDirection): [RegionRect, RegionRect] | null {
+  const rect = getCropBoundingRect(crop);
+  if (direction === "vertical") {
+    if (rect.width < MIN_SPLIT_SIZE * 2) return null;
+    const leftWidth = Math.round(rect.width / 2);
+    const rightWidth = rect.width - leftWidth;
+    return [
+      { x: rect.x, y: rect.y, width: leftWidth, height: rect.height },
+      { x: rect.x + leftWidth, y: rect.y, width: rightWidth, height: rect.height },
+    ];
+  }
+
+  if (rect.height < MIN_SPLIT_SIZE * 2) return null;
+  const topHeight = Math.round(rect.height / 2);
+  const bottomHeight = rect.height - topHeight;
+  return [
+    { x: rect.x, y: rect.y, width: rect.width, height: topHeight },
+    { x: rect.x, y: rect.y + topHeight, width: rect.width, height: bottomHeight },
+  ];
+}
+
+export function mergeCropRegions(first: PlantedCrop, second: PlantedCrop): RegionRect {
+  const a = getCropBoundingRect(first);
+  const b = getCropBoundingRect(second);
+  const minX = Math.min(a.x, b.x);
+  const minY = Math.min(a.y, b.y);
+  const maxX = Math.max(a.x + a.width, b.x + b.width);
+  const maxY = Math.max(a.y + a.height, b.y + b.height);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}


### PR DESCRIPTION
## Summary
- add in-place crop reassignment for selected planner regions without delete/recreate
- add region split operations (vertical/horizontal) with guardrails for minimum size
- add region merge operation to combine selected region with another growing region
- keep event history via existing planner update/add/remove events and add region-edit utility tests

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #36
