### PR TITLE
feat: infrastructure overlay for water and electricity

### DIFF
--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -74,6 +74,7 @@ export default function FieldPlannerPage() {
   const [selectedCropId, setSelectedCropId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>("");
   const [resizeMode, setResizeMode] = useState(false);
+  const [showUtilities, setShowUtilities] = useState(true);
   const [timelineDate, setTimelineDate] = useState("");
   const [remoteTimelineEvents, setRemoteTimelineEvents] = useState<PlannerEvent[] | null>(null);
   const [remoteAnchors, setRemoteAnchors] = useState<string[] | null>(null);
@@ -306,6 +307,8 @@ export default function FieldPlannerPage() {
                         selectedCropId={selectedCropId}
                         onSelectCrop={setSelectedCropId}
                         occurredAt={currentOccurredAt}
+                        showUtilities={showUtilities}
+                        onToggleUtilities={() => setShowUtilities((prev) => !prev)}
                       />
                       <Button size="sm" variant={resizeMode ? "default" : "outline"} onClick={() => setResizeMode(!resizeMode)}>
                         {resizeMode ? (
@@ -352,6 +355,7 @@ export default function FieldPlannerPage() {
                     occurredAt={currentOccurredAt}
                     showHarvestedCrops={showHarvestedCrops}
                     conflictedCropIds={Array.from(conflictedByField.get(field.id) ?? [])}
+                    showUtilities={showUtilities}
                   />
                 </TabsContent>
               ))}

--- a/src/lib/planner/events.ts
+++ b/src/lib/planner/events.ts
@@ -60,12 +60,16 @@ export function replayPlannerEvents(events: PlannerEvent[], options?: ReplayOpti
           name: string;
           dimensions: Field["dimensions"];
           context?: Partial<FieldContext>;
+          utilityNodes?: Field["utilityNodes"];
+          utilityEdges?: Field["utilityEdges"];
         };
         fieldsMap.set(payload.id, {
           id: payload.id,
           name: payload.name,
           dimensions: payload.dimensions,
           context: normalizeFieldContext(payload.context),
+          utilityNodes: Array.isArray(payload.utilityNodes) ? payload.utilityNodes : [],
+          utilityEdges: Array.isArray(payload.utilityEdges) ? payload.utilityEdges : [],
           plantedCrops: [],
         });
         break;
@@ -178,6 +182,8 @@ export function bootstrapEventsFromFields(fields: Field[]): PlannerEvent[] {
           name: field.name,
           dimensions: field.dimensions,
           context: normalizeFieldContext(field.context),
+          utilityNodes: field.utilityNodes ?? [],
+          utilityEdges: field.utilityEdges ?? [],
         },
       })
     );

--- a/src/lib/store/fields-context.tsx
+++ b/src/lib/store/fields-context.tsx
@@ -78,13 +78,21 @@ export function FieldsProvider({ children }: { children: ReactNode }) {
   const addField = useCallback(
     (name: string, width: number, height: number, options?: { occurredAt?: string; context?: Partial<FieldContext> }) => {
       const context = normalizeFieldContext(options?.context);
-      const newField: Field = { id: uuidv4(), name, dimensions: { width, height }, context, plantedCrops: [] };
+      const newField: Field = {
+        id: uuidv4(),
+        name,
+        dimensions: { width, height },
+        context,
+        utilityNodes: [],
+        utilityEdges: [],
+        plantedCrops: [],
+      };
       appendEvent(
         createPlannerEvent({
           type: "field_created",
           occurredAt: options?.occurredAt,
           fieldId: newField.id,
-          payload: { id: newField.id, name, dimensions: { width, height }, context },
+          payload: { id: newField.id, name, dimensions: { width, height }, context, utilityNodes: [], utilityEdges: [] },
         })
       );
       return newField;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -144,11 +144,29 @@ export interface FieldContext {
   windExposure: FieldWindExposure;
 }
 
+export type UtilityKind = "water" | "electric";
+
+export interface UtilityNode {
+  id: string;
+  label: string;
+  kind: UtilityKind;
+  position: CropPoint;
+}
+
+export interface UtilityEdge {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  kind: UtilityKind;
+}
+
 export interface Field {
   id: string;
   name: string;
   dimensions: { width: number; height: number }; // 公尺
   context: FieldContext;
+  utilityNodes?: UtilityNode[];
+  utilityEdges?: UtilityEdge[];
   plantedCrops: PlantedCrop[];
 }
 

--- a/src/lib/utils/field-context.test.ts
+++ b/src/lib/utils/field-context.test.ts
@@ -19,6 +19,8 @@ describe("field context normalization", () => {
     expect(normalizeField(legacy)).toEqual({
       ...legacy,
       context: defaultFieldContext,
+      utilityNodes: [],
+      utilityEdges: [],
     });
   });
 });

--- a/src/lib/utils/field-context.ts
+++ b/src/lib/utils/field-context.ts
@@ -33,6 +33,8 @@ export function normalizeField(field: LegacyField): Field {
   return {
     ...field,
     context: normalizeFieldContext(field.context),
+    utilityNodes: Array.isArray(field.utilityNodes) ? field.utilityNodes : [],
+    utilityEdges: Array.isArray(field.utilityEdges) ? field.utilityEdges : [],
   };
 }
 


### PR DESCRIPTION
## Summary
- extend field model with utility nodes/edges for water/electric infrastructure overlay
- add planner toolbar actions to toggle utility layer, add water/electric nodes, and connect nodes
- render utility overlay on canvas with draggable nodes and colored lines, while preserving timeline/event persistence via field updates
- keep legacy field compatibility by normalizing missing utility arrays

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #39
