### PR TITLE
feat: map/blueprint assisted zone bootstrap

### DIFF
--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -9,6 +9,7 @@ import { useAllCrops } from "@/lib/data/crop-lookup";
 import { useFields } from "@/lib/store/fields-context";
 import { FieldToolbar } from "@/components/field-planner/field-toolbar";
 import { FieldSettingsDialog } from "@/components/field-planner/field-settings-dialog";
+import { MapImportDialog } from "@/components/field-planner/map-import-dialog";
 import { TimelineSlider } from "@/components/field-planner/timeline-slider";
 import { Button } from "@/components/ui/button";
 import { evaluateFieldPlanningRules } from "@/lib/utils/rotation-companion-checker";
@@ -310,6 +311,7 @@ export default function FieldPlannerPage() {
                         showUtilities={showUtilities}
                         onToggleUtilities={() => setShowUtilities((prev) => !prev)}
                       />
+                      <MapImportDialog field={field} occurredAt={currentOccurredAt} />
                       <Button size="sm" variant={resizeMode ? "default" : "outline"} onClick={() => setResizeMode(!resizeMode)}>
                         {resizeMode ? (
                           <>

--- a/src/components/field-planner/map-import-dialog.tsx
+++ b/src/components/field-planner/map-import-dialog.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import NextImage from "next/image";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useAllCrops } from "@/lib/data/crop-lookup";
+import { useFields } from "@/lib/store/fields-context";
+import type { Field } from "@/lib/types";
+import { detectZonesFromImage, type ZoneCandidate } from "@/lib/utils/map-zone-detection";
+import { Upload } from "lucide-react";
+
+interface MapImportDialogProps {
+  field: Field;
+  occurredAt?: string;
+}
+
+
+export function MapImportDialog({ field, occurredAt }: MapImportDialogProps) {
+  const { addPlantedCrop } = useFields();
+  const allCrops = useAllCrops();
+  const [open, setOpen] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [zones, setZones] = useState<ZoneCandidate[]>([]);
+  const [status, setStatus] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const defaultCropId = allCrops[0]?.id ?? "";
+
+  const canApply = useMemo(
+    () => zones.length > 0 && zones.every((zone) => Boolean(zone.cropId)),
+    [zones]
+  );
+
+  const handleFileSelect = async (file: File | null) => {
+    if (!file || !defaultCropId) return;
+    setProcessing(true);
+    setStatus(null);
+
+    try {
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+      const image = new window.Image();
+      image.src = url;
+      await new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve();
+        image.onerror = () => reject(new Error("image-load-failed"));
+      });
+
+      const maxSize = 480;
+      const scale = Math.min(1, maxSize / Math.max(image.width, image.height));
+      const targetWidth = Math.max(1, Math.round(image.width * scale));
+      const targetHeight = Math.max(1, Math.round(image.height * scale));
+      const canvas = document.createElement("canvas");
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("canvas-context");
+
+      ctx.drawImage(image, 0, 0, targetWidth, targetHeight);
+      const imageData = ctx.getImageData(0, 0, targetWidth, targetHeight);
+      const detected = detectZonesFromImage(imageData, field, defaultCropId);
+      setZones(detected);
+      setStatus(detected.length > 0 ? `已偵測 ${detected.length} 個候選區域。` : "未偵測到可用分區，請換一張對比更高的圖。");
+    } catch {
+      setStatus("圖片分析失敗，請更換檔案後再試。");
+      setZones([]);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleApply = () => {
+    if (!canApply) return;
+    const plantedDate = occurredAt ?? new Date().toISOString();
+    zones.forEach((zone) => {
+      addPlantedCrop(
+        field.id,
+        {
+          cropId: zone.cropId,
+          fieldId: field.id,
+          plantedDate,
+          status: "growing",
+          position: { x: zone.x, y: zone.y },
+          size: { width: zone.width, height: zone.height },
+        },
+        { occurredAt: plantedDate }
+      );
+    });
+    setStatus(`已套用 ${zones.length} 個區域。`);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <Upload className="size-4 mr-1" />
+          匯入地圖分區
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>地圖/藍圖分區匯入</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(event) => handleFileSelect(event.target.files?.[0] ?? null)}
+          />
+
+          {previewUrl && (
+            <NextImage
+              src={previewUrl}
+              alt="map-preview"
+              width={480}
+              height={240}
+              unoptimized
+              className="max-h-48 rounded border object-contain"
+            />
+          )}
+
+          {zones.length > 0 && (
+            <ScrollArea className="h-60 rounded border p-2">
+              <div className="space-y-2">
+                {zones.map((zone, index) => (
+                  <div key={zone.id} className="rounded border p-2">
+                    <div className="mb-1 flex items-center gap-2 text-sm">
+                      <span className="inline-block h-3 w-3 rounded-full" style={{ backgroundColor: zone.color }} />
+                      <span>區域 {index + 1}</span>
+                      <span className="text-xs text-muted-foreground">
+                        ({Math.round(zone.width)}×{Math.round(zone.height)} cm)
+                      </span>
+                    </div>
+                    <Select
+                      value={zone.cropId}
+                      onValueChange={(value) =>
+                        setZones((prev) => prev.map((item) => (item.id === zone.id ? { ...item, cropId: value } : item)))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="選擇作物或設施" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {allCrops.map((crop) => (
+                          <SelectItem key={crop.id} value={crop.id}>
+                            {crop.emoji} {crop.name}（{crop.category}）
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+
+          <Button onClick={handleApply} disabled={!canApply || processing}>
+            套用偵測結果
+          </Button>
+          {status && <p className="text-xs text-muted-foreground">{status}</p>}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/utils/map-zone-detection.test.ts
+++ b/src/lib/utils/map-zone-detection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { detectZonesFromImage } from "@/lib/utils/map-zone-detection";
+import { defaultFieldContext } from "@/lib/utils/field-context";
+import type { Field } from "@/lib/types";
+
+function makeImageData(width: number, height: number, painter: (x: number, y: number) => [number, number, number, number]) {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (y * width + x) * 4;
+      const [r, g, b, a] = painter(x, y);
+      data[idx] = r;
+      data[idx + 1] = g;
+      data[idx + 2] = b;
+      data[idx + 3] = a;
+    }
+  }
+  return { width, height, data };
+}
+
+describe("detectZonesFromImage", () => {
+  const field: Field = {
+    id: "field-1",
+    name: "測試田區",
+    dimensions: { width: 4, height: 4 },
+    context: defaultFieldContext,
+    plantedCrops: [],
+    utilityNodes: [],
+    utilityEdges: [],
+  };
+
+  it("detects dominant color zones and maps to field coordinates", () => {
+    const imageData = makeImageData(4, 4, (x) => (x < 2 ? [200, 0, 0, 255] : [0, 200, 0, 255]));
+    const zones = detectZonesFromImage(imageData, field, "crop-1");
+
+    expect(zones.length).toBeGreaterThanOrEqual(2);
+    expect(zones.every((zone) => zone.cropId === "crop-1")).toBe(true);
+    expect(zones.some((zone) => zone.width >= 180)).toBe(true);
+  });
+});

--- a/src/lib/utils/map-zone-detection.ts
+++ b/src/lib/utils/map-zone-detection.ts
@@ -1,0 +1,107 @@
+import type { Field } from "@/lib/types";
+
+export interface ZoneCandidate {
+  id: string;
+  color: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  cropId: string;
+}
+
+export interface ImageLikeData {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+function rgbDistance(a: [number, number, number], b: [number, number, number]) {
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+}
+
+function toHex(r: number, g: number, b: number) {
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+export function detectZonesFromImage(imageData: ImageLikeData, field: Field, fallbackCropId: string): ZoneCandidate[] {
+  const quantize = 40;
+  const width = imageData.width;
+  const height = imageData.height;
+  const colorBuckets = new Map<string, { rgb: [number, number, number]; count: number }>();
+  const source = imageData.data;
+  const totalPixels = width * height;
+
+  for (let i = 0; i < source.length; i += 4) {
+    const r = source[i];
+    const g = source[i + 1];
+    const b = source[i + 2];
+    const alpha = source[i + 3];
+    if (alpha < 200) continue;
+    const brightness = (r + g + b) / 3;
+    if (brightness > 245) continue;
+    const keyR = Math.round(r / quantize) * quantize;
+    const keyG = Math.round(g / quantize) * quantize;
+    const keyB = Math.round(b / quantize) * quantize;
+    const key = `${keyR}-${keyG}-${keyB}`;
+    const bucket = colorBuckets.get(key);
+    if (bucket) {
+      bucket.count += 1;
+    } else {
+      colorBuckets.set(key, { rgb: [keyR, keyG, keyB], count: 1 });
+    }
+  }
+
+  const topColors = Array.from(colorBuckets.values())
+    .filter((bucket) => bucket.count >= totalPixels * 0.01)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8);
+
+  if (topColors.length === 0) return [];
+
+  const zones: ZoneCandidate[] = [];
+  topColors.forEach((bucket, colorIndex) => {
+    let minX = width;
+    let minY = height;
+    let maxX = 0;
+    let maxY = 0;
+    let hitCount = 0;
+
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const idx = (y * width + x) * 4;
+        const rgb: [number, number, number] = [source[idx], source[idx + 1], source[idx + 2]];
+        const alpha = source[idx + 3];
+        if (alpha < 200) continue;
+        if (rgbDistance(rgb, bucket.rgb) > 28) continue;
+        hitCount += 1;
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+      }
+    }
+
+    if (hitCount < totalPixels * 0.01) return;
+
+    const fieldWidthCm = field.dimensions.width * 100;
+    const fieldHeightCm = field.dimensions.height * 100;
+    const zoneWidth = Math.max(10, ((maxX - minX + 1) / width) * fieldWidthCm);
+    const zoneHeight = Math.max(10, ((maxY - minY + 1) / height) * fieldHeightCm);
+
+    zones.push({
+      id: `zone-${colorIndex}`,
+      color: toHex(bucket.rgb[0], bucket.rgb[1], bucket.rgb[2]),
+      x: (minX / width) * fieldWidthCm,
+      y: (minY / height) * fieldHeightCm,
+      width: zoneWidth,
+      height: zoneHeight,
+      cropId: fallbackCropId,
+    });
+  });
+
+  return zones;
+}


### PR DESCRIPTION
## Summary
- add map/blueprint import dialog in field planner for image-based initial zoning
- implement color-based zone detection utility and map detected regions to field coordinates
- let users assign each detected zone to any crop/facility category before applying
- add unit coverage for zone detection behavior

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #37
