### PR TITLE
feat: add planner memo panel with backup support

### DIFF
--- a/docs/plans/2026-02-18-planner-memo-panel-design.md
+++ b/docs/plans/2026-02-18-planner-memo-panel-design.md
@@ -1,0 +1,23 @@
+# Planner Memo Panel Design
+
+Date: 2026-02-18
+Related issue: #50
+Status: Implementation-ready
+
+## Objective
+
+Add a persistent memo area in Field Planner so users can keep non-structured notes tied to garden planning (facility reminders, path notes, maintenance logs).
+
+## Design
+
+- Add `PlannerMemoPanel` UI in `/field-planner`.
+- Persist memo content in local storage key `hualien-planner-memo`.
+- Store payload shape:
+  - `text`
+  - `updatedAt`
+- Include `hualien-planner-memo` in scheduled/manual planner backup key list.
+
+## Validation
+
+- Manual: memo remains after reload and app restart.
+- Backup integration: memo key captured/restored by existing backup utility tests that validate tracked key coverage.

--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -10,6 +10,7 @@ import { useFields } from "@/lib/store/fields-context";
 import { FieldToolbar } from "@/components/field-planner/field-toolbar";
 import { FieldSettingsDialog } from "@/components/field-planner/field-settings-dialog";
 import { MapImportDialog } from "@/components/field-planner/map-import-dialog";
+import { PlannerMemoPanel } from "@/components/field-planner/planner-memo-panel";
 import { TimelineSlider } from "@/components/field-planner/timeline-slider";
 import { Button } from "@/components/ui/button";
 import { evaluateFieldPlanningRules } from "@/lib/utils/rotation-companion-checker";
@@ -235,6 +236,8 @@ export default function FieldPlannerPage() {
         onChange={setTimelineDate}
         onReset={() => setTimelineDate("")}
       />
+
+      <PlannerMemoPanel />
 
       {conflictsAtView.length > 0 && (
         <Card className="border-red-200 bg-red-50/40">

--- a/src/components/field-planner/planner-memo-panel.tsx
+++ b/src/components/field-planner/planner-memo-panel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMemo } from "react";
+import { format } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+interface PlannerMemoState {
+  text: string;
+  updatedAt: string;
+}
+
+const defaultMemoState: PlannerMemoState = {
+  text: "",
+  updatedAt: "",
+};
+
+function formatUpdatedAt(value: string) {
+  if (!value) return "尚未更新";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "尚未更新";
+  return format(date, "yyyy/MM/dd HH:mm");
+}
+
+export function PlannerMemoPanel() {
+  const [memo, setMemo, isLoaded] = useLocalStorage<PlannerMemoState>("hualien-planner-memo", defaultMemoState);
+
+  const characterCount = useMemo(() => memo.text.length, [memo.text]);
+
+  if (!isLoaded) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">庭園 Memo</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">載入中...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">庭園 Memo</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Textarea
+          value={memo.text}
+          onChange={(event) =>
+            setMemo({
+              text: event.target.value,
+              updatedAt: new Date().toISOString(),
+            })
+          }
+          placeholder="記錄庭園配置備註、設備保養提醒、道路/水電注意事項..."
+          rows={5}
+        />
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>最後更新：{formatUpdatedAt(memo.updatedAt)}</span>
+          <span>{characterCount} 字</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/store/planner-backup.ts
+++ b/src/lib/store/planner-backup.ts
@@ -4,6 +4,7 @@ export const PLANNER_BACKUP_SCHEMA_VERSION = 1;
 
 export const PLANNER_BACKUP_DATA_KEYS = [
   "hualien-planner-events",
+  "hualien-planner-memo",
   "hualien-show-harvested",
   "hualien-tasks",
   "hualien-custom-crops",


### PR DESCRIPTION
## Summary
- add a persistent `庭園 Memo` panel in field planner with localStorage-backed notes and update timestamp
- integrate memo storage into planner backup tracked keys so weekly/monthly backups include memo content
- add design note for issue #50 in docs/plans

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #50
