### PR TITLE
feat: utility overlay management and orphan edge cleanup

### DIFF
--- a/docs/plans/2026-02-18-utility-overlay-management-design.md
+++ b/docs/plans/2026-02-18-utility-overlay-management-design.md
@@ -1,0 +1,63 @@
+# Utility Overlay Node/Edge Management Design
+
+Date: 2026-02-18
+Related issue: #52
+Status: Implementation-ready
+
+## Objective
+
+補足田園規劃水電圖層的維護能力，避免長期使用後留下無效連線，並讓使用者可以直接管理節點與邊線。
+
+## Problem
+
+- 目前支援新增節點與建立連線，但缺少刪除與清理流程。
+- 當節點被改名、同步或版本轉換後，可能殘留指向不存在節點的孤兒 edge。
+- 若未在 replay/normalize 層處理，舊資料可能持續污染新版本狀態。
+
+## Scope
+
+- Toolbar 新增「管理水電」入口。
+- 支援刪除指定節點並同步移除關聯連線。
+- 支援一鍵清除所有連線（保留節點）。
+- 在 field normalize 與 event replay 階段都進行 utility network 正規化。
+
+## Data Rules
+
+- Utility node 必須具備：
+  - `id` 非空字串
+  - `label` 非空字串
+  - `kind` 僅限 `water | electric`
+  - `position.x/y` 為 finite number
+- Utility edge 必須具備：
+  - `id`, `fromNodeId`, `toNodeId` 非空字串
+  - `fromNodeId !== toNodeId`
+  - `kind` 僅限 `water | electric`
+- Edge 最終需通過 node existence check；指向不存在節點即移除。
+
+## UI Behavior
+
+- `管理水電` Popover：
+  - 選擇既有節點後可執行刪除。
+  - 刪除前提示確認，避免誤刪。
+  - 提供一鍵清除連線按鈕。
+- 操作完成後即更新 field event stream，不直接改 local mutable state。
+
+## Replay/Compatibility
+
+- `normalizeField` 套用 `normalizeUtilityNetwork`，保證 legacy field 載入即清理孤兒 edge。
+- `replayPlannerEvents`：
+  - `field_created` 對 payload utility network 做正規化。
+  - `field_updated` 對「新 payload + 現有 field」合併結果做正規化，避免節點更新後遺留舊 edge。
+
+## Test Plan
+
+- `field-context.test.ts`：
+  - legacy field 轉換時會刪除 orphan edges。
+  - utility normalize 會濾除無效 node/edge。
+- `events.test.ts`：
+  - replay 在節點更新刪除後，會清掉關聯與孤兒 edges。
+
+## Out of Scope
+
+- 自動路徑規劃、最短路徑、拓樸最佳化。
+- 節點群組、圖層權限控制。

--- a/src/lib/planner/events.test.ts
+++ b/src/lib/planner/events.test.ts
@@ -157,6 +157,43 @@ describe("replayPlannerEvents", () => {
     });
   });
 
+  it("removes orphan utility edges during replay when nodes are deleted", () => {
+    const events: PlannerEvent[] = [
+      {
+        id: "1",
+        type: "field_created",
+        occurredAt: "2026-02-10T00:00:00.000Z",
+        fieldId: "field-1",
+        payload: {
+          id: "field-1",
+          name: "A 區",
+          dimensions: { width: 5, height: 4 },
+          utilityNodes: [
+            { id: "n1", label: "水節點 1", kind: "water", position: { x: 30, y: 20 } },
+            { id: "n2", label: "電節點 1", kind: "electric", position: { x: 50, y: 40 } },
+          ],
+          utilityEdges: [
+            { id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" },
+            { id: "e2", fromNodeId: "n1", toNodeId: "missing", kind: "water" },
+          ],
+        },
+      },
+      {
+        id: "2",
+        type: "field_updated",
+        occurredAt: "2026-02-11T00:00:00.000Z",
+        fieldId: "field-1",
+        payload: {
+          utilityNodes: [{ id: "n1", label: "水節點 1", kind: "water", position: { x: 30, y: 20 } }],
+        },
+      },
+    ];
+
+    const result = replayPlannerEvents(events);
+    expect(result[0]?.utilityNodes).toHaveLength(1);
+    expect(result[0]?.utilityEdges).toEqual([]);
+  });
+
   it("detects spatial conflict when polygon shape overlaps another region", () => {
     const events: PlannerEvent[] = [
       {

--- a/src/lib/utils/field-context.test.ts
+++ b/src/lib/utils/field-context.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { SunlightLevel, type Field } from "@/lib/types";
-import { defaultFieldContext, isSunlightCompatible, normalizeField, normalizeFieldContext } from "@/lib/utils/field-context";
+import {
+  defaultFieldContext,
+  isSunlightCompatible,
+  normalizeField,
+  normalizeFieldContext,
+  normalizeUtilityNetwork,
+} from "@/lib/utils/field-context";
 
 describe("field context normalization", () => {
   it("returns defaults when context is missing or invalid", () => {
@@ -22,6 +28,45 @@ describe("field context normalization", () => {
       utilityNodes: [],
       utilityEdges: [],
     });
+  });
+
+  it("drops orphan utility edges when normalizing legacy fields", () => {
+    const legacy = {
+      id: "field-2",
+      name: "B 區",
+      dimensions: { width: 6, height: 3 },
+      plantedCrops: [],
+      utilityNodes: [
+        { id: "n1", label: "水節點 1", kind: "water", position: { x: 10, y: 10 } },
+        { id: "n2", label: "電節點 1", kind: "electric", position: { x: 30, y: 20 } },
+      ],
+      utilityEdges: [
+        { id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" },
+        { id: "e2", fromNodeId: "n1", toNodeId: "missing", kind: "water" },
+      ],
+    } as unknown as Omit<Field, "context">;
+
+    const normalized = normalizeField(legacy);
+    expect(normalized.utilityNodes).toHaveLength(2);
+    expect(normalized.utilityEdges).toEqual([{ id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" }]);
+  });
+
+  it("normalizes utility nodes/edges and filters invalid entries", () => {
+    const normalized = normalizeUtilityNetwork({
+      utilityNodes: [
+        { id: "n1", label: "水節點", kind: "water", position: { x: "12", y: 30 } },
+        { id: "", label: "無效", kind: "water", position: { x: 0, y: 0 } },
+      ],
+      utilityEdges: [
+        { id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" },
+        { id: "e2", fromNodeId: "n1", toNodeId: "n1", kind: "water" },
+      ],
+    });
+
+    expect(normalized.utilityNodes).toEqual([
+      { id: "n1", label: "水節點", kind: "water", position: { x: 12, y: 30 } },
+    ]);
+    expect(normalized.utilityEdges).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add utility network normalization for nodes/edges and orphan edge filtering
- apply utility normalization in planner event replay for field create/update
- add toolbar management actions to delete a utility node with linked edges and clear all edges
- add design doc for issue #52 at docs/plans/2026-02-18-utility-overlay-management-design.md
- extend tests for utility normalization and replay cleanup behavior

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #52