### PR TITLE
feat: infrastructure facility metadata in planner

### DIFF
--- a/docs/plans/2026-02-18-infrastructure-facility-metadata-design.md
+++ b/docs/plans/2026-02-18-infrastructure-facility-metadata-design.md
@@ -1,0 +1,73 @@
+# Infrastructure Facility Metadata Design
+
+Date: 2026-02-18
+Related issue: #54
+Status: Implementation-ready
+
+## Objective
+
+讓 `其它類` 區域可直接記錄設施屬性（例如道路、蓄水池、馬達、工具間、房舍），提升地圖標示清楚度與資料可用性。
+
+## Problem
+
+- 現在雖可用 `其它類` 作物代表設施，但缺少結構化欄位。
+- 設施名稱目前只能依作物名稱推測，無法同類型多區域客製命名。
+- 沒有正規化規則可防止一般植栽誤帶設施欄位。
+
+## Data Model
+
+- 新增 `FacilityType`：
+  - `water_tank`
+  - `motor`
+  - `road`
+  - `tool_shed`
+  - `house`
+  - `custom`
+- 擴充 `PlantedCrop`：
+  - `facilityType?: FacilityType`
+  - `facilityName?: string`
+
+## Validation Rules
+
+- 若區域對應作物類別不是 `其它類`：
+  - 正規化時移除 `facilityType/facilityName`。
+- 若是 `其它類`：
+  - `facilityType` 必須為合法 enum，否則清空。
+  - `facilityName` 需 trim；空字串視為未設定。
+- 顯示標籤優先序：
+  - `facilityName`
+  - `facilityType` 對應中文名稱
+  - 原作物名稱
+
+## UI Changes
+
+- `FieldToolbar` 在選取 `其它類` 區域時顯示設施設定區塊：
+  - 設施類型下拉選單
+  - 設施名稱輸入框
+  - 變更即更新（型別即時更新、名稱於 blur 時更新）
+- 對非 `其它類` 區域隱藏此區塊。
+
+## Rendering Changes
+
+- `FieldCanvas` 文字標示改為：
+  - 若為設施區域，顯示 `facility label`（含客製名稱）。
+  - 非設施維持現行作物名稱。
+
+## Compatibility
+
+- 舊資料不含新欄位，預設視為 undefined。
+- 事件 replay 對 `crop_planted/crop_updated` 結果在顯示層採正規化，避免歷史髒資料影響新 UI。
+
+## Test Plan
+
+- 單元測試：
+  - 設施欄位正規化（合法/非法/空字串）。
+  - 非 `其它類` 自動清除設施欄位。
+  - 顯示標籤 helper 優先序測試。
+- 回歸測試：
+  - 一般作物區域顯示與功能不變。
+
+## Out of Scope
+
+- 設施與水電節點自動連結。
+- 新增設施 icon library 或 3D 視圖。

--- a/src/components/field-planner/field-canvas.tsx
+++ b/src/components/field-planner/field-canvas.tsx
@@ -9,6 +9,7 @@ import { useAllCrops } from "@/lib/data/crop-lookup";
 import { useFields } from "@/lib/store/fields-context";
 import { addDays, format } from "date-fns";
 import { getCropPolygon, polygonBounds, translatePoints } from "@/lib/utils/crop-shape";
+import { getPlantedCropDisplayLabel } from "@/lib/utils/facility-metadata";
 
 const PIXELS_PER_METER = 100;
 const MIN_SIZE_METERS = 1;
@@ -632,6 +633,7 @@ export default function FieldCanvas({
             const isHarvested = plantedCrop.status === "harvested";
             const growthDays = plantedCrop.customGrowthDays ?? cropData.growthDays;
             const expectedHarvestDate = format(addDays(new Date(plantedCrop.plantedDate), growthDays), "yyyy/MM/dd");
+            const displayLabel = getPlantedCropDisplayLabel(plantedCrop, cropData.name, cropData.category);
 
             return (
               <Group key={plantedCrop.id}>
@@ -691,7 +693,7 @@ export default function FieldCanvas({
                   />
                 )}
                 <Text x={rect.x + 4} y={rect.y + 4} text={cropData.emoji} fontSize={16} listening={false} />
-                <Text x={rect.x + 4} y={rect.y + 24} text={cropData.name} fontSize={10} fill="#374151" listening={false} />
+                <Text x={rect.x + 4} y={rect.y + 24} text={displayLabel} fontSize={10} fill="#374151" listening={false} />
                 {isHarvested && (
                   <Text x={rect.x + 4} y={rect.y + 36} text="已收成" fontSize={9} fill="#4b5563" listening={false} />
                 )}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -116,6 +116,8 @@ export interface PolygonCropShape {
 
 export type PlantedCropShape = PolygonCropShape;
 
+export type FacilityType = "water_tank" | "motor" | "road" | "tool_shed" | "house" | "custom";
+
 export interface PlantedCrop {
   id: string;
   cropId: string;
@@ -126,6 +128,8 @@ export interface PlantedCrop {
   position: { x: number; y: number };
   size: { width: number; height: number };
   shape?: PlantedCropShape;
+  facilityType?: FacilityType;
+  facilityName?: string;
   customGrowthDays?: number;
   notes?: string;
 }

--- a/src/lib/utils/facility-metadata.test.ts
+++ b/src/lib/utils/facility-metadata.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { CropCategory, type PlantedCrop } from "@/lib/types";
+import {
+  getPlantedCropDisplayLabel,
+  normalizePlantedCropFacilityMetadata,
+  normalizeFacilityName,
+  normalizeFacilityType,
+} from "@/lib/utils/facility-metadata";
+
+function planted(overrides?: Partial<PlantedCrop>): PlantedCrop {
+  return {
+    id: "pc-1",
+    cropId: "crop-1",
+    fieldId: "field-1",
+    plantedDate: "2026-02-01T00:00:00.000Z",
+    status: "growing",
+    position: { x: 10, y: 10 },
+    size: { width: 50, height: 50 },
+    ...overrides,
+  };
+}
+
+describe("facility metadata normalization", () => {
+  it("drops facility fields for non-infrastructure categories", () => {
+    const normalized = normalizePlantedCropFacilityMetadata(
+      planted({ facilityType: "road", facilityName: "南側道路" }),
+      CropCategory.葉菜類
+    );
+    expect("facilityType" in normalized).toBe(false);
+    expect("facilityName" in normalized).toBe(false);
+  });
+
+  it("keeps valid facility fields for infrastructure categories", () => {
+    const normalized = normalizePlantedCropFacilityMetadata(
+      planted({ facilityType: "water_tank", facilityName: "  北側蓄水池  " }),
+      CropCategory.其它類
+    );
+    expect(normalized.facilityType).toBe("water_tank");
+    expect(normalized.facilityName).toBe("北側蓄水池");
+  });
+
+  it("keeps sanitized facility fields when category is unknown", () => {
+    const normalized = normalizePlantedCropFacilityMetadata(
+      planted({ facilityType: "custom", facilityName: "  臨時設施  " }),
+      undefined
+    );
+    expect(normalized.facilityType).toBe("custom");
+    expect(normalized.facilityName).toBe("臨時設施");
+  });
+
+  it("removes invalid facility values", () => {
+    expect(normalizeFacilityType("invalid")).toBeUndefined();
+    expect(normalizeFacilityName("   ")).toBeUndefined();
+  });
+});
+
+describe("facility display label", () => {
+  it("prefers custom facility name then facility type label", () => {
+    expect(
+      getPlantedCropDisplayLabel({ facilityName: "東側馬達區", facilityType: "motor" }, "其它設施", CropCategory.其它類)
+    ).toBe("東側馬達區");
+    expect(getPlantedCropDisplayLabel({ facilityType: "road" }, "其它設施", CropCategory.其它類)).toBe("道路");
+  });
+
+  it("falls back to crop name for non-infrastructure categories", () => {
+    expect(getPlantedCropDisplayLabel({ facilityType: "road", facilityName: "A" }, "番茄", CropCategory.茄果類)).toBe("番茄");
+  });
+});

--- a/src/lib/utils/facility-metadata.ts
+++ b/src/lib/utils/facility-metadata.ts
@@ -1,0 +1,75 @@
+import { CropCategory, type FacilityType, type PlantedCrop } from "@/lib/types";
+
+const facilityTypeLabels: Record<FacilityType, string> = {
+  water_tank: "蓄水池",
+  motor: "馬達",
+  road: "道路",
+  tool_shed: "工具間",
+  house: "房舍",
+  custom: "其它設施",
+};
+
+const facilityTypeOptions = Object.keys(facilityTypeLabels) as FacilityType[];
+const facilityTypeSet = new Set<FacilityType>(facilityTypeOptions);
+
+export function getFacilityTypeOptions(): Array<{ value: FacilityType; label: string }> {
+  return facilityTypeOptions.map((value) => ({
+    value,
+    label: facilityTypeLabels[value],
+  }));
+}
+
+export function getFacilityTypeLabel(type: FacilityType): string {
+  return facilityTypeLabels[type];
+}
+
+export function normalizeFacilityType(input: unknown): FacilityType | undefined {
+  if (typeof input !== "string") return undefined;
+  if (!facilityTypeSet.has(input as FacilityType)) return undefined;
+  return input as FacilityType;
+}
+
+export function normalizeFacilityName(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const normalized = input.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function normalizePlantedCropFacilityMetadata(plantedCrop: PlantedCrop, category?: CropCategory): PlantedCrop {
+  if (category === undefined) {
+    return {
+      ...plantedCrop,
+      facilityType: normalizeFacilityType(plantedCrop.facilityType),
+      facilityName: normalizeFacilityName(plantedCrop.facilityName),
+    };
+  }
+
+  if (category !== CropCategory.其它類) {
+    const withoutFacilityFields = { ...plantedCrop };
+    delete withoutFacilityFields.facilityType;
+    delete withoutFacilityFields.facilityName;
+    return withoutFacilityFields;
+  }
+
+  return {
+    ...plantedCrop,
+    facilityType: normalizeFacilityType(plantedCrop.facilityType),
+    facilityName: normalizeFacilityName(plantedCrop.facilityName),
+  };
+}
+
+export function getPlantedCropDisplayLabel(
+  plantedCrop: Pick<PlantedCrop, "facilityType" | "facilityName">,
+  cropName: string,
+  category?: CropCategory
+): string {
+  if (category !== CropCategory.其它類) return cropName;
+
+  const facilityName = normalizeFacilityName(plantedCrop.facilityName);
+  if (facilityName) return facilityName;
+
+  const facilityType = normalizeFacilityType(plantedCrop.facilityType);
+  if (facilityType) return getFacilityTypeLabel(facilityType);
+
+  return cropName;
+}


### PR DESCRIPTION
## Summary
- add typed acilityType and acilityName on planted regions
- add facility metadata normalization + display label helpers
- normalize facility metadata in FieldsProvider using crop categories
- add planner toolbar controls for infrastructure facility type/name editing
- render facility display labels on planner canvas
- add design doc for #54 at docs/plans/2026-02-18-infrastructure-facility-metadata-design.md
- add tests for facility normalization and label fallbacks

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #54