### PR TITLE
feat: link infrastructure regions with utility nodes

### DIFF
--- a/docs/plans/2026-02-18-facility-utility-linking-design.md
+++ b/docs/plans/2026-02-18-facility-utility-linking-design.md
@@ -1,0 +1,59 @@
+# Facility-Utility Linking Design
+
+Date: 2026-02-18
+Related issue: #56
+Status: Implementation-ready
+
+## Objective
+
+讓 `其它類` 設施區域可關聯到水/電節點，補齊「設施位置」與「管線節點」之間的語意連結。
+
+## Problem
+
+- 目前設施與 utility overlay 互相獨立。
+- 維運時無法快速辨識某區域對應哪些節點。
+
+## Data Model
+
+- 擴充 `PlantedCrop`：
+  - `linkedUtilityNodeIds?: string[]`
+
+## Normalization Rules
+
+- 只有 `其它類` 區域保留 `linkedUtilityNodeIds`。
+- 清理規則：
+  - 非字串或空字串 ID 移除。
+  - 重複 ID 去重。
+  - 不存在於該 field `utilityNodes` 的 ID 移除。
+- 非 `其它類` 區域一律移除該欄位。
+
+## UI Changes
+
+- `FieldToolbar` 在「設施設定」中新增節點多選清單：
+  - 點擊可切換關聯/取消關聯。
+  - 僅顯示現有 utility nodes。
+- 無 utility nodes 時顯示提示文字。
+
+## Rendering Changes
+
+- `FieldCanvas` 設施名稱下方顯示連結摘要：
+  - `已連結 N 節點`（N > 0 時）。
+
+## Compatibility
+
+- 舊資料未含欄位時視為空陣列語意。
+- 若節點被刪除，關聯在正規化時自動清理孤兒 ID。
+
+## Test Plan
+
+- 單元測試：
+  - 關聯 ID 去重與無效值移除。
+  - 非 `其它類` 區域移除關聯欄位。
+  - 顯示摘要文案生成測試。
+- 回歸測試：
+  - 無關聯時既有作物顯示不變。
+
+## Out of Scope
+
+- 設施到節點的路徑可視化高亮。
+- 巡檢排程或故障告警流程。

--- a/src/components/field-planner/field-canvas.tsx
+++ b/src/components/field-planner/field-canvas.tsx
@@ -9,7 +9,7 @@ import { useAllCrops } from "@/lib/data/crop-lookup";
 import { useFields } from "@/lib/store/fields-context";
 import { addDays, format } from "date-fns";
 import { getCropPolygon, polygonBounds, translatePoints } from "@/lib/utils/crop-shape";
-import { getPlantedCropDisplayLabel } from "@/lib/utils/facility-metadata";
+import { getLinkedUtilitySummary, getPlantedCropDisplayLabel } from "@/lib/utils/facility-metadata";
 
 const PIXELS_PER_METER = 100;
 const MIN_SIZE_METERS = 1;
@@ -634,6 +634,7 @@ export default function FieldCanvas({
             const growthDays = plantedCrop.customGrowthDays ?? cropData.growthDays;
             const expectedHarvestDate = format(addDays(new Date(plantedCrop.plantedDate), growthDays), "yyyy/MM/dd");
             const displayLabel = getPlantedCropDisplayLabel(plantedCrop, cropData.name, cropData.category);
+            const utilitySummary = getLinkedUtilitySummary(plantedCrop, cropData.category);
 
             return (
               <Group key={plantedCrop.id}>
@@ -696,6 +697,9 @@ export default function FieldCanvas({
                 <Text x={rect.x + 4} y={rect.y + 24} text={displayLabel} fontSize={10} fill="#374151" listening={false} />
                 {isHarvested && (
                   <Text x={rect.x + 4} y={rect.y + 36} text="已收成" fontSize={9} fill="#4b5563" listening={false} />
+                )}
+                {utilitySummary && (
+                  <Text x={rect.x + 4} y={rect.y + (isHarvested ? 48 : 36)} text={utilitySummary} fontSize={9} fill="#0f766e" listening={false} />
                 )}
                 {isSelected && (
                   <Text

--- a/src/lib/store/fields-context.tsx
+++ b/src/lib/store/fields-context.tsx
@@ -49,12 +49,15 @@ export function FieldsProvider({ children }: { children: ReactNode }) {
   const cropCategoryById = useMemo(() => new Map(customCrops.map((crop) => [crop.id, crop.category])), [customCrops]);
 
   const normalizeFieldFacilities = useCallback(
-    (field: Field): Field => ({
-      ...field,
-      plantedCrops: field.plantedCrops.map((crop) =>
-        normalizePlantedCropFacilityMetadata(crop, cropCategoryById.get(crop.cropId))
-      ),
-    }),
+    (field: Field): Field => {
+      const validNodeIds = new Set((field.utilityNodes ?? []).map((node) => node.id));
+      return {
+        ...field,
+        plantedCrops: field.plantedCrops.map((crop) =>
+          normalizePlantedCropFacilityMetadata(crop, cropCategoryById.get(crop.cropId), validNodeIds)
+        ),
+      };
+    },
     [cropCategoryById]
   );
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -130,6 +130,7 @@ export interface PlantedCrop {
   shape?: PlantedCropShape;
   facilityType?: FacilityType;
   facilityName?: string;
+  linkedUtilityNodeIds?: string[];
   customGrowthDays?: number;
   notes?: string;
 }

--- a/src/lib/utils/facility-metadata.ts
+++ b/src/lib/utils/facility-metadata.ts
@@ -35,12 +35,35 @@ export function normalizeFacilityName(input: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-export function normalizePlantedCropFacilityMetadata(plantedCrop: PlantedCrop, category?: CropCategory): PlantedCrop {
+export function normalizeLinkedUtilityNodeIds(input: unknown, validNodeIds?: Set<string>): string[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const item of input) {
+    if (typeof item !== "string") continue;
+    const nodeId = item.trim();
+    if (!nodeId) continue;
+    if (validNodeIds && !validNodeIds.has(nodeId)) continue;
+    if (seen.has(nodeId)) continue;
+    seen.add(nodeId);
+    deduped.push(nodeId);
+  }
+
+  return deduped.length > 0 ? deduped : undefined;
+}
+
+export function normalizePlantedCropFacilityMetadata(
+  plantedCrop: PlantedCrop,
+  category?: CropCategory,
+  validUtilityNodeIds?: Set<string>
+): PlantedCrop {
   if (category === undefined) {
     return {
       ...plantedCrop,
       facilityType: normalizeFacilityType(plantedCrop.facilityType),
       facilityName: normalizeFacilityName(plantedCrop.facilityName),
+      linkedUtilityNodeIds: normalizeLinkedUtilityNodeIds(plantedCrop.linkedUtilityNodeIds, validUtilityNodeIds),
     };
   }
 
@@ -48,6 +71,7 @@ export function normalizePlantedCropFacilityMetadata(plantedCrop: PlantedCrop, c
     const withoutFacilityFields = { ...plantedCrop };
     delete withoutFacilityFields.facilityType;
     delete withoutFacilityFields.facilityName;
+    delete withoutFacilityFields.linkedUtilityNodeIds;
     return withoutFacilityFields;
   }
 
@@ -55,6 +79,7 @@ export function normalizePlantedCropFacilityMetadata(plantedCrop: PlantedCrop, c
     ...plantedCrop,
     facilityType: normalizeFacilityType(plantedCrop.facilityType),
     facilityName: normalizeFacilityName(plantedCrop.facilityName),
+    linkedUtilityNodeIds: normalizeLinkedUtilityNodeIds(plantedCrop.linkedUtilityNodeIds, validUtilityNodeIds),
   };
 }
 
@@ -72,4 +97,14 @@ export function getPlantedCropDisplayLabel(
   if (facilityType) return getFacilityTypeLabel(facilityType);
 
   return cropName;
+}
+
+export function getLinkedUtilitySummary(
+  plantedCrop: Pick<PlantedCrop, "linkedUtilityNodeIds">,
+  category?: CropCategory
+): string | null {
+  if (category !== CropCategory.其它類) return null;
+  const linked = normalizeLinkedUtilityNodeIds(plantedCrop.linkedUtilityNodeIds);
+  if (!linked || linked.length === 0) return null;
+  return `已連結 ${linked.length} 節點`;
 }


### PR DESCRIPTION
## Summary
- add linkedUtilityNodeIds support for planted regions
- extend facility metadata normalization to dedupe/filter linked utility node ids
- enforce infrastructure-only retention for facility/link metadata in field normalization
- add toolbar controls to link/unlink utility nodes for selected infrastructure regions
- show linked utility summary text on planner canvas
- add design doc for #56 at docs/plans/2026-02-18-facility-utility-linking-design.md
- extend unit tests for linked-id normalization and summary rendering logic

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #56