### PR TITLE
feat: add utility node type profiles

### DIFF
--- a/docs/plans/2026-02-18-utility-node-type-profiles-design.md
+++ b/docs/plans/2026-02-18-utility-node-type-profiles-design.md
@@ -1,0 +1,60 @@
+# Utility Node Type Profiles Design
+
+Date: 2026-02-18
+Related issue: #58
+Status: Implementation-ready
+
+## Objective
+
+在既有 `water/electric` 基礎上補上節點子類型語意，提升水電圖層可讀性與維護效率。
+
+## Data Model
+
+- `UtilityNode` 新增：
+  - `nodeType?: UtilityNodeType`
+- `UtilityNodeType`：
+  - `pump`
+  - `tank`
+  - `valve`
+  - `outlet`
+  - `junction`
+  - `custom`
+
+## Rule Set
+
+- `kind` 與 `nodeType` 合法組合：
+  - `water`: `pump | tank | valve | junction | custom`
+  - `electric`: `outlet | junction | custom`
+- 非法組合 fallback：
+  - `water -> junction`
+  - `electric -> outlet`
+
+## UI Changes
+
+- 新增節點時可選擇 nodeType。
+- 管理水電面板新增節點編輯：
+  - 選取節點
+  - 調整 nodeType
+  - 調整 label
+
+## Rendering
+
+- 節點顏色仍以 `kind` 決定。
+- 文字顯示為：
+  - `nodeType 中文名`
+  - 若有自訂 label，顯示 `nodeType中文 - label`。
+
+## Compatibility
+
+- 舊資料沒有 `nodeType` 時，以 `kind` 對應預設值補齊。
+
+## Test Plan
+
+- nodeType 正規化（合法/非法組合）。
+- fallback 規則測試。
+- 顯示標籤組裝測試。
+
+## Out of Scope
+
+- 水電負載模擬。
+- 自動偵測節點功能。

--- a/src/components/field-planner/field-canvas.tsx
+++ b/src/components/field-planner/field-canvas.tsx
@@ -10,6 +10,7 @@ import { useFields } from "@/lib/store/fields-context";
 import { addDays, format } from "date-fns";
 import { getCropPolygon, polygonBounds, translatePoints } from "@/lib/utils/crop-shape";
 import { getLinkedUtilitySummary, getPlantedCropDisplayLabel } from "@/lib/utils/facility-metadata";
+import { formatUtilityNodeDisplayLabel } from "@/lib/utils/utility-node";
 
 const PIXELS_PER_METER = 100;
 const MIN_SIZE_METERS = 1;
@@ -609,7 +610,7 @@ export default function FieldCanvas({
                 <Text
                   x={node.position.x + 8}
                   y={node.position.y - 6}
-                  text={node.label}
+                  text={formatUtilityNodeDisplayLabel(node)}
                   fontSize={10}
                   fill={node.kind === "water" ? "#0369a1" : "#9a3412"}
                 />

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -150,11 +150,13 @@ export interface FieldContext {
 }
 
 export type UtilityKind = "water" | "electric";
+export type UtilityNodeType = "pump" | "tank" | "valve" | "outlet" | "junction" | "custom";
 
 export interface UtilityNode {
   id: string;
   label: string;
   kind: UtilityKind;
+  nodeType?: UtilityNodeType;
   position: CropPoint;
 }
 

--- a/src/lib/utils/field-context.test.ts
+++ b/src/lib/utils/field-context.test.ts
@@ -47,7 +47,10 @@ describe("field context normalization", () => {
     } as unknown as Omit<Field, "context">;
 
     const normalized = normalizeField(legacy);
-    expect(normalized.utilityNodes).toHaveLength(2);
+    expect(normalized.utilityNodes).toEqual([
+      { id: "n1", label: "水節點 1", kind: "water", nodeType: "junction", position: { x: 10, y: 10 } },
+      { id: "n2", label: "電節點 1", kind: "electric", nodeType: "outlet", position: { x: 30, y: 20 } },
+    ]);
     expect(normalized.utilityEdges).toEqual([{ id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" }]);
   });
 
@@ -64,9 +67,24 @@ describe("field context normalization", () => {
     });
 
     expect(normalized.utilityNodes).toEqual([
-      { id: "n1", label: "水節點", kind: "water", position: { x: 12, y: 30 } },
+      { id: "n1", label: "水節點", kind: "water", nodeType: "junction", position: { x: 12, y: 30 } },
     ]);
     expect(normalized.utilityEdges).toEqual([]);
+  });
+
+  it("normalizes utility node type by kind and falls back for invalid combos", () => {
+    const normalized = normalizeUtilityNetwork({
+      utilityNodes: [
+        { id: "w1", label: "水點", kind: "water", nodeType: "outlet", position: { x: 10, y: 10 } },
+        { id: "e1", label: "電點", kind: "electric", nodeType: "pump", position: { x: 20, y: 20 } },
+      ],
+      utilityEdges: [],
+    });
+
+    expect(normalized.utilityNodes).toEqual([
+      { id: "w1", label: "水點", kind: "water", nodeType: "junction", position: { x: 10, y: 10 } },
+      { id: "e1", label: "電點", kind: "electric", nodeType: "outlet", position: { x: 20, y: 20 } },
+    ]);
   });
 });
 

--- a/src/lib/utils/field-context.ts
+++ b/src/lib/utils/field-context.ts
@@ -1,4 +1,5 @@
 import { SunlightLevel, type Field, type FieldContext, type FieldSunHours, type UtilityEdge, type UtilityNode } from "@/lib/types";
+import { normalizeUtilityNodeType } from "@/lib/utils/utility-node";
 
 export const defaultFieldContext: FieldContext = {
   plotType: "open_field",
@@ -44,6 +45,7 @@ function normalizeUtilityNode(input: unknown): UtilityNode | null {
     id: raw.id,
     label: raw.label,
     kind: raw.kind,
+    nodeType: normalizeUtilityNodeType(raw.kind, raw.nodeType),
     position: { x, y },
   };
 }

--- a/src/lib/utils/utility-node.test.ts
+++ b/src/lib/utils/utility-node.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatUtilityNodeDisplayLabel, normalizeUtilityNodeType } from "@/lib/utils/utility-node";
+
+describe("utility node type normalization", () => {
+  it("accepts valid type/kind pairs", () => {
+    expect(normalizeUtilityNodeType("water", "pump")).toBe("pump");
+    expect(normalizeUtilityNodeType("electric", "junction")).toBe("junction");
+  });
+
+  it("falls back when type is invalid for kind", () => {
+    expect(normalizeUtilityNodeType("water", "outlet")).toBe("junction");
+    expect(normalizeUtilityNodeType("electric", "tank")).toBe("outlet");
+  });
+});
+
+describe("utility node display label", () => {
+  it("prefixes label with node type", () => {
+    expect(formatUtilityNodeDisplayLabel({ kind: "water", nodeType: "tank", label: "北側" })).toBe("蓄水池 - 北側");
+  });
+
+  it("avoids duplicate prefix when label already contains type", () => {
+    expect(formatUtilityNodeDisplayLabel({ kind: "electric", nodeType: "outlet", label: "插座 A1" })).toBe("插座 A1");
+  });
+});

--- a/src/lib/utils/utility-node.ts
+++ b/src/lib/utils/utility-node.ts
@@ -1,0 +1,41 @@
+import type { UtilityKind, UtilityNode, UtilityNodeType } from "@/lib/types";
+
+const utilityNodeTypeByKind: Record<UtilityKind, UtilityNodeType[]> = {
+  water: ["pump", "tank", "valve", "junction", "custom"],
+  electric: ["outlet", "junction", "custom"],
+};
+
+const utilityNodeTypeLabels: Record<UtilityNodeType, string> = {
+  pump: "馬達",
+  tank: "蓄水池",
+  valve: "閥門",
+  outlet: "插座",
+  junction: "節點",
+  custom: "自訂",
+};
+
+export function getDefaultUtilityNodeType(kind: UtilityKind): UtilityNodeType {
+  return kind === "water" ? "junction" : "outlet";
+}
+
+export function getUtilityNodeTypeOptions(kind: UtilityKind): UtilityNodeType[] {
+  return utilityNodeTypeByKind[kind];
+}
+
+export function getUtilityNodeTypeLabel(type: UtilityNodeType): string {
+  return utilityNodeTypeLabels[type];
+}
+
+export function normalizeUtilityNodeType(kind: UtilityKind, nodeType: unknown): UtilityNodeType {
+  if (typeof nodeType !== "string") return getDefaultUtilityNodeType(kind);
+  const typed = nodeType as UtilityNodeType;
+  return utilityNodeTypeByKind[kind].includes(typed) ? typed : getDefaultUtilityNodeType(kind);
+}
+
+export function formatUtilityNodeDisplayLabel(node: Pick<UtilityNode, "label" | "kind" | "nodeType">): string {
+  const typeLabel = getUtilityNodeTypeLabel(normalizeUtilityNodeType(node.kind, node.nodeType));
+  const rawLabel = typeof node.label === "string" ? node.label.trim() : "";
+  if (!rawLabel) return typeLabel;
+  if (rawLabel.startsWith(typeLabel)) return rawLabel;
+  return `${typeLabel} - ${rawLabel}`;
+}


### PR DESCRIPTION
## Summary
- add UtilityNodeType support and 
odeType field on utility nodes
- add utility node type helper utilities (normalization, labels, display formatting)
- normalize utility node type by kind in field utility network normalization
- update field toolbar to create nodes with kind + nodeType + optional label
- extend utility management panel to edit selected node type and label
- show normalized utility node display labels on planner canvas
- add design doc for #58 at docs/plans/2026-02-18-utility-node-type-profiles-design.md
- add tests for utility node type normalization and display labels

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #58