### PR TITLE
feat: auto-derive facility type defaults

### DIFF
--- a/docs/plans/2026-02-18-facility-type-defaults-design.md
+++ b/docs/plans/2026-02-18-facility-type-defaults-design.md
@@ -1,0 +1,47 @@
+# Facility Type Default Derivation Design
+
+Date: 2026-02-18
+Related issue: #62
+Status: Implementation-ready
+
+## Objective
+
+降低 `其它類` 設施資料的手動補填成本，讓 `facilityType` 在建立或改派時自動帶入可用預設。
+
+## Mapping Rule
+
+- 設施作物名稱對應：
+  - `蓄水池` -> `water_tank`
+  - `馬達` -> `motor`
+  - `道路` -> `road`
+  - `工具間` -> `tool_shed`
+  - `房舍` -> `house`
+- 未命中映射時保持原行為（不強制填值）。
+
+## Preservation Rule
+
+- 若使用者已有合法 `facilityType`，不被自動推斷覆蓋。
+- 僅在 `facilityType` 缺失或無效時套用推斷值。
+
+## Integration Points
+
+- `FieldToolbar`：
+  - 新增作物時若為 `其它類`，自動帶入推斷 `facilityType`。
+  - 更改作物改派到 `其它類` 時，若舊值無效/缺失，套用推斷值。
+- `MapImportDialog`：
+  - 套用匯入區域時，對設施作物寫入推斷 `facilityType`。
+- `FieldsProvider` normalize：
+  - 若 category 已知為 `其它類` 且 `facilityType` 無效，補推斷值（僅 normalization 階段）。
+
+## Test Plan
+
+- 單元測試：
+  - 作物名稱對應推斷結果。
+  - 已有合法值時不覆蓋。
+  - 無映射名稱時回傳 undefined。
+- 回歸：
+  - 非 `其它類` 不注入設施欄位。
+
+## Out of Scope
+
+- 自動產生 `facilityName` 或命名序號。

--- a/src/components/field-planner/field-toolbar.tsx
+++ b/src/components/field-planner/field-toolbar.tsx
@@ -14,6 +14,7 @@ import { isInfrastructureCategory, type Field, type UtilityKind, type UtilityNod
 import { polygonBounds, toTrapezoidPoints } from "@/lib/utils/crop-shape";
 import { mergeCropRegions, splitCropRegion, type SplitDirection } from "@/lib/utils/region-edit";
 import {
+  deriveFacilityTypeFromCrop,
   getFacilityTypeOptions,
   normalizeFacilityName,
   normalizeFacilityType,
@@ -114,6 +115,7 @@ export function FieldToolbar({ field, selectedCropId, onSelectCrop, occurredAt, 
         status: "growing",
         position: { x: 50 + column * 70, y: 50 + row * 70 },
         size: { width: crop.spacing.plant, height: crop.spacing.row },
+        facilityType: deriveFacilityTypeFromCrop(crop),
       },
       { occurredAt: plantedDate }
     );
@@ -164,7 +166,9 @@ export function FieldToolbar({ field, selectedCropId, onSelectCrop, occurredAt, 
       {
         cropId: nextCropId,
         ...(isInfrastructureCategory(nextCrop.category)
-          ? {}
+          ? {
+              facilityType: normalizeFacilityType(selectedPlanted.facilityType) ?? deriveFacilityTypeFromCrop(nextCrop),
+            }
           : { facilityType: undefined, facilityName: undefined, linkedUtilityNodeIds: undefined }),
       },
       { occurredAt }

--- a/src/components/field-planner/map-import-dialog.tsx
+++ b/src/components/field-planner/map-import-dialog.tsx
@@ -16,6 +16,7 @@ import {
   type ImageLikeData,
   type ZoneCandidate,
 } from "@/lib/utils/map-zone-detection";
+import { deriveFacilityTypeFromCrop } from "@/lib/utils/facility-metadata";
 import { Upload } from "lucide-react";
 
 interface MapImportDialogProps {
@@ -39,6 +40,7 @@ export function MapImportDialog({ field, occurredAt }: MapImportDialogProps) {
 
   const defaultCropId = allCrops[0]?.id ?? "";
   const [bulkCropId, setBulkCropId] = useState("");
+  const cropById = useMemo(() => new Map(allCrops.map((crop) => [crop.id, crop])), [allCrops]);
 
   const canApply = useMemo(
     () => zones.length > 0 && zones.every((zone) => Boolean(zone.cropId)),
@@ -141,6 +143,7 @@ export function MapImportDialog({ field, occurredAt }: MapImportDialogProps) {
     if (!canApply) return;
     const plantedDate = occurredAt ?? new Date().toISOString();
     zones.forEach((zone) => {
+      const crop = cropById.get(zone.cropId);
       addPlantedCrop(
         field.id,
         {
@@ -150,6 +153,7 @@ export function MapImportDialog({ field, occurredAt }: MapImportDialogProps) {
           status: "growing",
           position: { x: zone.x, y: zone.y },
           size: { width: zone.width, height: zone.height },
+          facilityType: deriveFacilityTypeFromCrop(crop),
         },
         { occurredAt: plantedDate }
       );

--- a/src/lib/store/fields-context.tsx
+++ b/src/lib/store/fields-context.tsx
@@ -46,7 +46,10 @@ export function FieldsProvider({ children }: { children: ReactNode }) {
   const [plannerEvents, setPlannerEvents, isLoaded] = useLocalStorage<PlannerEvent[]>("hualien-planner-events", []);
   const [showHarvestedCrops, setShowHarvestedCrops] = useLocalStorage<boolean>("hualien-show-harvested", true);
   const { customCrops } = useCustomCrops();
-  const cropCategoryById = useMemo(() => new Map(customCrops.map((crop) => [crop.id, crop.category])), [customCrops]);
+  const cropMetaById = useMemo(
+    () => new Map(customCrops.map((crop) => [crop.id, { category: crop.category, name: crop.name }])),
+    [customCrops]
+  );
 
   const normalizeFieldFacilities = useCallback(
     (field: Field): Field => {
@@ -54,11 +57,16 @@ export function FieldsProvider({ children }: { children: ReactNode }) {
       return {
         ...field,
         plantedCrops: field.plantedCrops.map((crop) =>
-          normalizePlantedCropFacilityMetadata(crop, cropCategoryById.get(crop.cropId), validNodeIds)
+          normalizePlantedCropFacilityMetadata(
+            crop,
+            cropMetaById.get(crop.cropId)?.category,
+            validNodeIds,
+            cropMetaById.get(crop.cropId)?.name
+          )
         ),
       };
     },
-    [cropCategoryById]
+    [cropMetaById]
   );
 
   const fields = useMemo(


### PR DESCRIPTION
## Summary
- add facility-type inference helpers based on infrastructure crop names
- preserve valid user-selected acilityType and only infer when missing/invalid
- apply inferred facility type when adding/reassigning infrastructure regions from toolbar
- apply inferred facility type when importing map zones into planted regions
- apply normalization fallback inference in FieldsProvider when infrastructure crop metadata is known
- add design doc for #62 at docs/plans/2026-02-18-facility-type-defaults-design.md
- extend facility metadata tests for inference and non-overwrite behavior

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #62