### PR TITLE
feat: enforce utility edge kind and node kind consistency

### DIFF
--- a/docs/plans/2026-02-18-utility-edge-kind-consistency-design.md
+++ b/docs/plans/2026-02-18-utility-edge-kind-consistency-design.md
@@ -1,0 +1,37 @@
+# Utility Edge Kind Consistency Design
+
+Date: 2026-02-18
+Related issue: #64
+Status: Implementation-ready
+
+## Objective
+
+確保 utility graph 的 `edge.kind` 與端點節點種類一致，避免水電語意混亂。
+
+## Rules
+
+- `water` edge 只能連接 `water` nodes。
+- `electric` edge 只能連接 `electric` nodes。
+- 若任一端節點不存在或種類不符，edge 在 normalize/replay 時移除。
+
+## UI Behavior
+
+- 連接節點面板中：
+  - 起點/終點列表依 `edgeKind` 過濾。
+  - 切換 `edgeKind` 時，若既有選擇不再合法，自動清空。
+- 連線建立前再次檢查合法性，避免 race 狀態下產生髒資料。
+
+## Data Compatibility
+
+- 舊資料中不一致 edge 透過 `normalizeUtilityNetwork` 自動清理，不需破壞性 migration。
+
+## Test Plan
+
+- `field-context.test.ts`：
+  - 混合 kind edge 會被過濾。
+- `events.test.ts`（可選補充）：
+  - replay 時不一致 edge 不會進入結果 state。
+
+## Out of Scope
+
+- 跨系統轉接器節點（例如水電混合節點）建模。

--- a/src/lib/planner/events.test.ts
+++ b/src/lib/planner/events.test.ts
@@ -194,6 +194,30 @@ describe("replayPlannerEvents", () => {
     expect(result[0]?.utilityEdges).toEqual([]);
   });
 
+  it("filters utility edges with node kind mismatch during replay", () => {
+    const events: PlannerEvent[] = [
+      {
+        id: "1",
+        type: "field_created",
+        occurredAt: "2026-02-10T00:00:00.000Z",
+        fieldId: "field-1",
+        payload: {
+          id: "field-1",
+          name: "A 區",
+          dimensions: { width: 5, height: 4 },
+          utilityNodes: [
+            { id: "w1", label: "水節點", kind: "water", position: { x: 30, y: 20 } },
+            { id: "e1", label: "電節點", kind: "electric", position: { x: 60, y: 20 } },
+          ],
+          utilityEdges: [{ id: "x1", fromNodeId: "w1", toNodeId: "e1", kind: "water" }],
+        },
+      },
+    ];
+
+    const result = replayPlannerEvents(events);
+    expect(result[0]?.utilityEdges).toEqual([]);
+  });
+
   it("detects spatial conflict when polygon shape overlaps another region", () => {
     const events: PlannerEvent[] = [
       {

--- a/src/lib/utils/field-context.test.ts
+++ b/src/lib/utils/field-context.test.ts
@@ -39,9 +39,10 @@ describe("field context normalization", () => {
       utilityNodes: [
         { id: "n1", label: "水節點 1", kind: "water", position: { x: 10, y: 10 } },
         { id: "n2", label: "電節點 1", kind: "electric", position: { x: 30, y: 20 } },
+        { id: "n3", label: "水節點 2", kind: "water", position: { x: 50, y: 20 } },
       ],
       utilityEdges: [
-        { id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" },
+        { id: "e1", fromNodeId: "n1", toNodeId: "n3", kind: "water" },
         { id: "e2", fromNodeId: "n1", toNodeId: "missing", kind: "water" },
       ],
     } as unknown as Omit<Field, "context">;
@@ -50,24 +51,28 @@ describe("field context normalization", () => {
     expect(normalized.utilityNodes).toEqual([
       { id: "n1", label: "水節點 1", kind: "water", nodeType: "junction", position: { x: 10, y: 10 } },
       { id: "n2", label: "電節點 1", kind: "electric", nodeType: "outlet", position: { x: 30, y: 20 } },
+      { id: "n3", label: "水節點 2", kind: "water", nodeType: "junction", position: { x: 50, y: 20 } },
     ]);
-    expect(normalized.utilityEdges).toEqual([{ id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" }]);
+    expect(normalized.utilityEdges).toEqual([{ id: "e1", fromNodeId: "n1", toNodeId: "n3", kind: "water" }]);
   });
 
   it("normalizes utility nodes/edges and filters invalid entries", () => {
     const normalized = normalizeUtilityNetwork({
       utilityNodes: [
         { id: "n1", label: "水節點", kind: "water", position: { x: "12", y: 30 } },
+        { id: "n2", label: "電節點", kind: "electric", position: { x: 40, y: 30 } },
         { id: "", label: "無效", kind: "water", position: { x: 0, y: 0 } },
       ],
       utilityEdges: [
         { id: "e1", fromNodeId: "n1", toNodeId: "n2", kind: "water" },
         { id: "e2", fromNodeId: "n1", toNodeId: "n1", kind: "water" },
+        { id: "e3", fromNodeId: "n1", toNodeId: "n2", kind: "electric" },
       ],
     });
 
     expect(normalized.utilityNodes).toEqual([
       { id: "n1", label: "水節點", kind: "water", nodeType: "junction", position: { x: 12, y: 30 } },
+      { id: "n2", label: "電節點", kind: "electric", nodeType: "outlet", position: { x: 40, y: 30 } },
     ]);
     expect(normalized.utilityEdges).toEqual([]);
   });

--- a/src/lib/utils/field-context.ts
+++ b/src/lib/utils/field-context.ts
@@ -74,11 +74,15 @@ export function normalizeUtilityNetwork(input?: {
   const nodes = (Array.isArray(input?.utilityNodes) ? input?.utilityNodes : [])
     .map((item) => normalizeUtilityNode(item))
     .filter((item): item is UtilityNode => item !== null);
-  const nodeIds = new Set(nodes.map((node) => node.id));
+  const nodeKindById = new Map(nodes.map((node) => [node.id, node.kind]));
   const edges = (Array.isArray(input?.utilityEdges) ? input?.utilityEdges : [])
     .map((item) => normalizeUtilityEdge(item))
     .filter((item): item is UtilityEdge => item !== null)
-    .filter((edge) => nodeIds.has(edge.fromNodeId) && nodeIds.has(edge.toNodeId));
+    .filter((edge) => {
+      const fromKind = nodeKindById.get(edge.fromNodeId);
+      const toKind = nodeKindById.get(edge.toNodeId);
+      return fromKind === edge.kind && toKind === edge.kind;
+    });
   return { utilityNodes: nodes, utilityEdges: edges };
 }
 


### PR DESCRIPTION
## Summary
- enforce utility edge filtering so edge kind must match both endpoint node kinds
- extend replay/normalization coverage with tests for kind-mismatched edges
- update connect-node UI to show only nodes matching selected edge kind
- ensure connect action validates selected nodes against current edge kind before creating edge
- add design doc for #64 at docs/plans/2026-02-18-utility-edge-kind-consistency-design.md

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #64