### PR TITLE
feat: add utility visibility filters by kind

### DIFF
--- a/docs/plans/2026-02-18-utility-layer-visibility-filters-design.md
+++ b/docs/plans/2026-02-18-utility-layer-visibility-filters-design.md
@@ -1,0 +1,41 @@
+# Utility Layer Visibility Filters Design
+
+Date: 2026-02-18
+Related issue: #66
+Status: Implementation-ready
+
+## Objective
+
+降低水電圖層密度高時的視覺干擾，提供水/電子圖層獨立顯示控制。
+
+## UI Model
+
+- 保留原有總開關 `showUtilities`。
+- 新增種類開關：
+  - `showWaterUtilities`
+  - `showElectricUtilities`
+- 總開關關閉時，種類開關不生效（全部隱藏）。
+
+## Rendering Rule
+
+- 節點顯示條件：
+  - `showUtilities && (node.kind === "water" ? showWaterUtilities : showElectricUtilities)`
+- 連線顯示條件：
+  - `showUtilities && (edge.kind === "water" ? showWaterUtilities : showElectricUtilities)`
+
+## Data & State
+
+- 僅 UI 層可視性狀態，不改動 `Field` 資料。
+- 不影響 event replay 或 normalize。
+
+## Test Plan
+
+- 新增 utility filter helper 的單元測試：
+  - 總開關關閉 -> 不顯示任何 node/edge
+  - 僅 water 開啟 -> 顯示 water node/edge
+  - 僅 electric 開啟 -> 顯示 electric node/edge
+
+## Out of Scope
+
+- 圖層透明度控制。
+- 類別分組折疊面板。

--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -77,6 +77,8 @@ export default function FieldPlannerPage() {
   const [activeTab, setActiveTab] = useState<string>("");
   const [resizeMode, setResizeMode] = useState(false);
   const [showUtilities, setShowUtilities] = useState(true);
+  const [showWaterUtilities, setShowWaterUtilities] = useState(true);
+  const [showElectricUtilities, setShowElectricUtilities] = useState(true);
   const [timelineDate, setTimelineDate] = useState("");
   const [remoteTimelineEvents, setRemoteTimelineEvents] = useState<PlannerEvent[] | null>(null);
   const [remoteAnchors, setRemoteAnchors] = useState<string[] | null>(null);
@@ -312,7 +314,16 @@ export default function FieldPlannerPage() {
                         onSelectCrop={setSelectedCropId}
                         occurredAt={currentOccurredAt}
                         showUtilities={showUtilities}
+                        showWaterUtilities={showWaterUtilities}
+                        showElectricUtilities={showElectricUtilities}
                         onToggleUtilities={() => setShowUtilities((prev) => !prev)}
+                        onToggleUtilityKind={(kind) => {
+                          if (kind === "water") {
+                            setShowWaterUtilities((prev) => !prev);
+                            return;
+                          }
+                          setShowElectricUtilities((prev) => !prev);
+                        }}
                       />
                       <MapImportDialog field={field} occurredAt={currentOccurredAt} />
                       <Button size="sm" variant={resizeMode ? "default" : "outline"} onClick={() => setResizeMode(!resizeMode)}>
@@ -361,6 +372,8 @@ export default function FieldPlannerPage() {
                     showHarvestedCrops={showHarvestedCrops}
                     conflictedCropIds={Array.from(conflictedByField.get(field.id) ?? [])}
                     showUtilities={showUtilities}
+                    showWaterUtilities={showWaterUtilities}
+                    showElectricUtilities={showElectricUtilities}
                   />
                 </TabsContent>
               ))}

--- a/src/components/field-planner/field-toolbar.tsx
+++ b/src/components/field-planner/field-toolbar.tsx
@@ -38,10 +38,23 @@ interface FieldToolbarProps {
   onSelectCrop: (id: string | null) => void;
   occurredAt?: string;
   showUtilities: boolean;
+  showWaterUtilities: boolean;
+  showElectricUtilities: boolean;
   onToggleUtilities: () => void;
+  onToggleUtilityKind: (kind: UtilityKind) => void;
 }
 
-export function FieldToolbar({ field, selectedCropId, onSelectCrop, occurredAt, showUtilities, onToggleUtilities }: FieldToolbarProps) {
+export function FieldToolbar({
+  field,
+  selectedCropId,
+  onSelectCrop,
+  occurredAt,
+  showUtilities,
+  showWaterUtilities,
+  showElectricUtilities,
+  onToggleUtilities,
+  onToggleUtilityKind,
+}: FieldToolbarProps) {
   const {
     addPlantedCrop,
     updatePlantedCrop,
@@ -442,6 +455,20 @@ export function FieldToolbar({ field, selectedCropId, onSelectCrop, occurredAt, 
       </Button>
       <Button size="sm" variant="outline" onClick={onToggleUtilities}>
         {showUtilities ? "隱藏水電" : "顯示水電"}
+      </Button>
+      <Button
+        size="sm"
+        variant={showWaterUtilities ? "default" : "outline"}
+        onClick={() => onToggleUtilityKind("water")}
+      >
+        水線
+      </Button>
+      <Button
+        size="sm"
+        variant={showElectricUtilities ? "default" : "outline"}
+        onClick={() => onToggleUtilityKind("electric")}
+      >
+        電線
       </Button>
       <Popover open={addUtilityOpen} onOpenChange={setAddUtilityOpen}>
         <PopoverTrigger asChild>

--- a/src/lib/utils/utility-visibility.test.ts
+++ b/src/lib/utils/utility-visibility.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { filterVisibleUtilityEdges, filterVisibleUtilityNodes, isUtilityKindVisible } from "@/lib/utils/utility-visibility";
+
+describe("utility visibility filters", () => {
+  it("hides all utilities when global toggle is off", () => {
+    expect(isUtilityKindVisible("water", { showUtilities: false, showWaterUtilities: true, showElectricUtilities: true })).toBe(false);
+    expect(isUtilityKindVisible("electric", { showUtilities: false, showWaterUtilities: true, showElectricUtilities: true })).toBe(false);
+  });
+
+  it("shows only enabled utility kinds", () => {
+    expect(isUtilityKindVisible("water", { showUtilities: true, showWaterUtilities: true, showElectricUtilities: false })).toBe(true);
+    expect(isUtilityKindVisible("electric", { showUtilities: true, showWaterUtilities: true, showElectricUtilities: false })).toBe(false);
+  });
+
+  it("filters nodes and edges by utility visibility", () => {
+    const nodes = [
+      { id: "w1", label: "W1", kind: "water" as const, position: { x: 0, y: 0 } },
+      { id: "e1", label: "E1", kind: "electric" as const, position: { x: 10, y: 0 } },
+    ];
+    const edges = [
+      { id: "we", fromNodeId: "w1", toNodeId: "w1", kind: "water" as const },
+      { id: "ee", fromNodeId: "e1", toNodeId: "e1", kind: "electric" as const },
+    ];
+
+    const visibility = { showUtilities: true, showWaterUtilities: false, showElectricUtilities: true };
+    expect(filterVisibleUtilityNodes(nodes, visibility).map((item) => item.id)).toEqual(["e1"]);
+    expect(filterVisibleUtilityEdges(edges, visibility).map((item) => item.id)).toEqual(["ee"]);
+  });
+});

--- a/src/lib/utils/utility-visibility.ts
+++ b/src/lib/utils/utility-visibility.ts
@@ -1,0 +1,21 @@
+import type { UtilityEdge, UtilityKind, UtilityNode } from "@/lib/types";
+
+export interface UtilityVisibility {
+  showUtilities: boolean;
+  showWaterUtilities: boolean;
+  showElectricUtilities: boolean;
+}
+
+export function isUtilityKindVisible(kind: UtilityKind, visibility: UtilityVisibility): boolean {
+  if (!visibility.showUtilities) return false;
+  if (kind === "water") return visibility.showWaterUtilities;
+  return visibility.showElectricUtilities;
+}
+
+export function filterVisibleUtilityNodes(nodes: UtilityNode[], visibility: UtilityVisibility): UtilityNode[] {
+  return nodes.filter((node) => isUtilityKindVisible(node.kind, visibility));
+}
+
+export function filterVisibleUtilityEdges(edges: UtilityEdge[], visibility: UtilityVisibility): UtilityEdge[] {
+  return edges.filter((edge) => isUtilityKindVisible(edge.kind, visibility));
+}


### PR DESCRIPTION
## Summary
- add water/electric sub-toggles alongside the existing utility layer global toggle
- propagate utility visibility state through field planner page into toolbar/canvas
- render utility nodes/edges by visibility filter without changing underlying field data
- add utility visibility helper utilities and unit tests
- add design doc for #66 at docs/plans/2026-02-18-utility-layer-visibility-filters-design.md

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #66