### PR TITLE
fix: cleanup map import object URL lifecycle

### DIFF
--- a/docs/plans/2026-02-18-map-import-url-lifecycle-design.md
+++ b/docs/plans/2026-02-18-map-import-url-lifecycle-design.md
@@ -1,0 +1,40 @@
+# Map Import Object URL Lifecycle Design
+
+Date: 2026-02-18
+Related issue: #70
+Status: Implementation-ready
+
+## Objective
+
+避免 map import 圖片預覽使用 object URL 時的記憶體累積，建立一致的釋放與狀態復位機制。
+
+## Lifecycle Rules
+
+- 上傳新檔案前，若存在舊 object URL，先 `URL.revokeObjectURL`。
+- Dialog 關閉時，釋放當前 object URL 並清空暫存狀態。
+- 元件卸載時，釋放當前 object URL。
+
+## State Reset Scope
+
+- `previewUrl`
+- `previewSize`
+- `imageData`
+- `zones`
+- `calibrationPoints`
+- `status`
+- `processing`
+
+## Implementation Notes
+
+- 抽出 `safeRevokeObjectUrl(url)` helper，集中 null/empty 防護。
+- 確保任何 early return/error path 都不遺漏 URL 釋放。
+
+## Test Plan
+
+- 單元測試：
+  - `safeRevokeObjectUrl` 對空值不呼叫 revoke
+  - 有效字串會呼叫 revoke 一次
+
+## Out of Scope
+
+- 圖片解碼效能優化。

--- a/src/lib/utils/object-url.test.ts
+++ b/src/lib/utils/object-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { safeRevokeObjectUrl } from "@/lib/utils/object-url";
+
+describe("safeRevokeObjectUrl", () => {
+  it("does not call revoke for invalid url values", () => {
+    const revoke = vi.fn();
+    safeRevokeObjectUrl(undefined, revoke);
+    safeRevokeObjectUrl(null, revoke);
+    safeRevokeObjectUrl("   ", revoke);
+    expect(revoke).not.toHaveBeenCalled();
+  });
+
+  it("calls revoke once for valid url", () => {
+    const revoke = vi.fn();
+    safeRevokeObjectUrl(" blob:test-url ", revoke);
+    expect(revoke).toHaveBeenCalledTimes(1);
+    expect(revoke).toHaveBeenCalledWith("blob:test-url");
+  });
+});

--- a/src/lib/utils/object-url.ts
+++ b/src/lib/utils/object-url.ts
@@ -1,0 +1,6 @@
+export function safeRevokeObjectUrl(url: string | null | undefined, revoke: (url: string) => void = URL.revokeObjectURL) {
+  if (typeof url !== "string") return;
+  const normalized = url.trim();
+  if (!normalized) return;
+  revoke(normalized);
+}


### PR DESCRIPTION
## Summary
- add safeRevokeObjectUrl helper to centralize object URL cleanup logic
- revoke previous preview URL when selecting a new map import file
- revoke current preview URL when dialog closes or import fails
- ensure dialog close path resets map import transient state
- add unmount cleanup for preview URL
- add design doc for #70 at docs/plans/2026-02-18-map-import-url-lifecycle-design.md
- add unit tests for object URL cleanup helper

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #70