### PR TITLE
feat: add keyboard shortcuts for timeline navigation

### DIFF
--- a/docs/plans/2026-02-18-timeline-keyboard-navigation-design.md
+++ b/docs/plans/2026-02-18-timeline-keyboard-navigation-design.md
@@ -1,0 +1,41 @@
+# Timeline Keyboard Navigation Design
+
+Date: 2026-02-18
+Related issue: #74
+Status: Implementation-ready
+
+## Objective
+
+提升時間軸無滑鼠操作效率，支援聚焦後的鍵盤快捷導航。
+
+## Shortcut Map
+
+- `ArrowLeft`: `-1 day`
+- `ArrowRight`: `+1 day`
+- `Shift + ArrowLeft`: `-7 days`
+- `Shift + ArrowRight`: `+7 days`
+- `PageUp`: `-1 month`
+- `PageDown`: `+1 month`
+- `Home`: reset timeline to today (`onReset`)
+
+## Focus & Scope
+
+- 時間軸主容器 `tabIndex=0`，可被鍵盤聚焦。
+- 僅在容器本身接收 keydown 時生效。
+- 若事件來源是 `input`/`textarea`/`select`，不攔截快捷鍵。
+
+## Implementation
+
+- 抽出 key-to-action helper，回傳 `deltaDays | deltaMonths | reset`。
+- `TimelineSlider` 使用 helper 分派到既有 `moveByDays` / `moveByMonths` / `onReset`。
+
+## Test Plan
+
+- helper 單元測試：
+  - Arrow/Page/Home 對應正確
+  - Shift 修飾鍵分支正確
+  - 不支援按鍵回傳 null
+
+## Out of Scope
+
+- 跨頁全域快捷鍵註冊。

--- a/src/lib/utils/timeline-shortcuts.test.ts
+++ b/src/lib/utils/timeline-shortcuts.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveTimelineShortcut } from "@/lib/utils/timeline-shortcuts";
+
+describe("resolveTimelineShortcut", () => {
+  it("maps arrow keys to day deltas", () => {
+    expect(resolveTimelineShortcut({ key: "ArrowLeft" })).toEqual({ type: "days", delta: -1 });
+    expect(resolveTimelineShortcut({ key: "ArrowRight" })).toEqual({ type: "days", delta: 1 });
+    expect(resolveTimelineShortcut({ key: "ArrowLeft", shiftKey: true })).toEqual({ type: "days", delta: -7 });
+    expect(resolveTimelineShortcut({ key: "ArrowRight", shiftKey: true })).toEqual({ type: "days", delta: 7 });
+  });
+
+  it("maps page keys and home key", () => {
+    expect(resolveTimelineShortcut({ key: "PageUp" })).toEqual({ type: "months", delta: -1 });
+    expect(resolveTimelineShortcut({ key: "PageDown" })).toEqual({ type: "months", delta: 1 });
+    expect(resolveTimelineShortcut({ key: "Home" })).toEqual({ type: "reset" });
+  });
+
+  it("returns null for unsupported keys", () => {
+    expect(resolveTimelineShortcut({ key: "Enter" })).toBeNull();
+  });
+});

--- a/src/lib/utils/timeline-shortcuts.ts
+++ b/src/lib/utils/timeline-shortcuts.ts
@@ -1,0 +1,24 @@
+export type TimelineShortcutAction =
+  | { type: "days"; delta: number }
+  | { type: "months"; delta: number }
+  | { type: "reset" };
+
+export function resolveTimelineShortcut(input: { key: string; shiftKey?: boolean }): TimelineShortcutAction | null {
+  const shiftKey = input.shiftKey ?? false;
+  if (input.key === "ArrowLeft") {
+    return { type: "days", delta: shiftKey ? -7 : -1 };
+  }
+  if (input.key === "ArrowRight") {
+    return { type: "days", delta: shiftKey ? 7 : 1 };
+  }
+  if (input.key === "PageUp") {
+    return { type: "months", delta: -1 };
+  }
+  if (input.key === "PageDown") {
+    return { type: "months", delta: 1 };
+  }
+  if (input.key === "Home") {
+    return { type: "reset" };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add timeline keyboard shortcut resolver utility
- support timeline shortcuts on focused container:
  - ArrowLeft/ArrowRight for day step
  - Shift+ArrowLeft/Shift+ArrowRight for week step
  - PageUp/PageDown for month step
  - Home for reset-to-now
- avoid shortcut interception when focused on editable inputs
- add design doc for #74 at docs/plans/2026-02-18-timeline-keyboard-navigation-design.md
- add unit tests for shortcut mapping

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #74