### PR TITLE
feat: persist selected timeline date

### DIFF
--- a/docs/plans/2026-02-18-timeline-date-persistence-design.md
+++ b/docs/plans/2026-02-18-timeline-date-persistence-design.md
@@ -1,0 +1,34 @@
+# Timeline Date Persistence Design
+
+Date: 2026-02-18
+Related issue: #76
+Status: Implementation-ready
+
+## Objective
+
+保留時間軸使用者當前檢視日期，避免重新整理後失去歷史追溯上下文。
+
+## Storage
+
+- key: `hualien-planner-timeline-date`
+- value: `YYYY-MM-DD` 或空字串
+
+## Normalization
+
+- 僅接受 `YYYY-MM-DD` 格式。
+- 非法值回退 `""`（表示「現在」模式）。
+
+## Behavior
+
+- 日期切換時即更新儲存值。
+- 點擊「回到現在」時清空儲存值。
+
+## Test Plan
+
+- 單元測試：
+  - 合法日期保留
+  - 非法型別/格式回退空字串
+
+## Out of Scope
+
+- URL query 共享與深連結。

--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -20,6 +20,7 @@ import {
   defaultUtilityVisibilitySettings,
   normalizeUtilityVisibilitySettings,
 } from "@/lib/utils/utility-visibility-settings";
+import { normalizeTimelineSelectedDate } from "@/lib/utils/timeline-date";
 import { Trash2, Move, MousePointer, AlertTriangle } from "lucide-react";
 
 const FieldCanvas = dynamic(() => import("@/components/field-planner/field-canvas"), {
@@ -85,7 +86,7 @@ export default function FieldPlannerPage() {
     "hualien-utility-visibility",
     defaultUtilityVisibilitySettings
   );
-  const [timelineDate, setTimelineDate] = useState("");
+  const [rawTimelineDate, setRawTimelineDate] = useLocalStorage("hualien-planner-timeline-date", "");
   const [remoteTimelineEvents, setRemoteTimelineEvents] = useState<PlannerEvent[] | null>(null);
   const [remoteAnchors, setRemoteAnchors] = useState<string[] | null>(null);
 
@@ -126,6 +127,7 @@ export default function FieldPlannerPage() {
     () => normalizeUtilityVisibilitySettings(rawUtilityVisibility),
     [rawUtilityVisibility]
   );
+  const timelineDate = useMemo(() => normalizeTimelineSelectedDate(rawTimelineDate), [rawTimelineDate]);
 
   const timelineAnchors = useMemo(() => {
     if (remoteAnchors && remoteAnchors.length > 0) return remoteAnchors;
@@ -246,8 +248,8 @@ export default function FieldPlannerPage() {
         anchors={timelineAnchors}
         value={timelineDate}
         events={mergedEvents}
-        onChange={setTimelineDate}
-        onReset={() => setTimelineDate("")}
+        onChange={(value) => setRawTimelineDate(normalizeTimelineSelectedDate(value))}
+        onReset={() => setRawTimelineDate("")}
       />
 
       <PlannerMemoPanel />

--- a/src/lib/utils/timeline-date.test.ts
+++ b/src/lib/utils/timeline-date.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTimelineSelectedDate } from "@/lib/utils/timeline-date";
+
+describe("normalizeTimelineSelectedDate", () => {
+  it("keeps valid YYYY-MM-DD values", () => {
+    expect(normalizeTimelineSelectedDate("2026-02-18")).toBe("2026-02-18");
+  });
+
+  it("returns empty string for invalid values", () => {
+    expect(normalizeTimelineSelectedDate("")).toBe("");
+    expect(normalizeTimelineSelectedDate("2026/02/18")).toBe("");
+    expect(normalizeTimelineSelectedDate("invalid")).toBe("");
+    expect(normalizeTimelineSelectedDate(123)).toBe("");
+  });
+});

--- a/src/lib/utils/timeline-date.ts
+++ b/src/lib/utils/timeline-date.ts
@@ -1,0 +1,8 @@
+const timelineDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+export function normalizeTimelineSelectedDate(input: unknown): string {
+  if (typeof input !== "string") return "";
+  const value = input.trim();
+  if (!value) return "";
+  return timelineDatePattern.test(value) ? value : "";
+}


### PR DESCRIPTION
## Summary
- persist selected planner timeline date in localStorage
- add selected-date normalization helper to guard invalid stored values
- integrate normalized persisted timeline date into field planner page state
- keep reset-to-now behavior by clearing persisted date on reset
- add design doc for #76 at docs/plans/2026-02-18-timeline-date-persistence-design.md
- add unit tests for timeline date normalization

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #76