### PR TITLE
feat: persist map import calibration distance

### DIFF
--- a/docs/plans/2026-02-18-map-import-calibration-distance-persistence-design.md
+++ b/docs/plans/2026-02-18-map-import-calibration-distance-persistence-design.md
@@ -1,0 +1,35 @@
+# Map Import Calibration Distance Persistence Design
+
+Date: 2026-02-18
+Related issue: #78
+Status: Implementation-ready
+
+## Objective
+
+保留 map import 兩點校正距離偏好，降低重複輸入成本。
+
+## Storage
+
+- key: `hualien-map-import-calibration-distance`
+- value: number string（公尺）
+
+## Normalization
+
+- 允許正數且大於 0。
+- 非法值回退 `"5"`。
+
+## Integration
+
+- `MapImportDialog` 以 `useLocalStorage` 管理距離值。
+- 距離輸入欄綁定持久化狀態。
+- 清除校正點僅清除點位，不清除距離偏好。
+
+## Test Plan
+
+- 單元測試：
+  - 合法數值字串保留
+  - 非法字串與負值回退預設
+
+## Out of Scope
+
+- 單位換算與公英制切換。

--- a/src/lib/utils/map-import-settings.test.ts
+++ b/src/lib/utils/map-import-settings.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultCalibrationDistance,
+  normalizeCalibrationDistanceStored,
+  parseCalibrationDistanceMeters,
+} from "@/lib/utils/map-import-settings";
+
+describe("map import calibration distance settings", () => {
+  it("parses positive number strings", () => {
+    expect(parseCalibrationDistanceMeters("5")).toBe(5);
+    expect(parseCalibrationDistanceMeters("2.5")).toBe(2.5);
+  });
+
+  it("returns null for invalid calibration strings", () => {
+    expect(parseCalibrationDistanceMeters("0")).toBeNull();
+    expect(parseCalibrationDistanceMeters("-3")).toBeNull();
+    expect(parseCalibrationDistanceMeters("abc")).toBeNull();
+  });
+
+  it("normalizes invalid stored values to default", () => {
+    expect(normalizeCalibrationDistanceStored("abc")).toBe(defaultCalibrationDistance);
+    expect(normalizeCalibrationDistanceStored("-1")).toBe(defaultCalibrationDistance);
+  });
+});

--- a/src/lib/utils/map-import-settings.ts
+++ b/src/lib/utils/map-import-settings.ts
@@ -1,0 +1,14 @@
+export const defaultCalibrationDistance = "5";
+
+export function parseCalibrationDistanceMeters(input: unknown): number | null {
+  if (typeof input !== "string") return null;
+  const value = Number(input);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+export function normalizeCalibrationDistanceStored(input: unknown): string {
+  const parsed = parseCalibrationDistanceMeters(typeof input === "string" ? input.trim() : input);
+  if (parsed === null) return defaultCalibrationDistance;
+  return String(parsed);
+}


### PR DESCRIPTION
## Summary
- persist map import calibration distance preference in localStorage
- add calibration distance parse/normalize helpers with safe default fallback
- normalize stored distance once after load while preserving user input editing flow
- keep calibration clear action focused on points only (distance preference retained)
- add design doc for #78 at docs/plans/2026-02-18-map-import-calibration-distance-persistence-design.md
- add unit tests for calibration distance settings helpers

## Testing
- bun run lint
- bunx tsc --noEmit
- bun test

Closes #78