### PR TITLE
feat: Grid Planner V2 workflow + flexible grid settings

### DIFF
--- a/docs/plans/2026-02-18-grid-planner-v2-redesign.md
+++ b/docs/plans/2026-02-18-grid-planner-v2-redesign.md
@@ -1,0 +1,155 @@
+# Grid Planner V2 Redesign Design Doc
+
+Date: 2026-02-18
+Issue: #80
+Status: Draft for implementation
+
+## 1. 背景與痛點
+
+目前田地規劃器存在三個核心問題：
+
+1. 語意錯置
+- 「新增作物」清單同時包含房舍、道路、蓄水池等設施。
+- 使用者認知上會把非植栽項目誤解為作物資料。
+
+2. 互動流程僵硬
+- 新增區域採固定欄位排列（5 欄 + 固定間距），不反映實際田區空間與已占用區。
+- 格線密度固定，無法依場景切換粗細與吸附需求。
+
+3. 前端維護成本高
+- 畫布互動邏輯與 Konva 事件高度耦合，難以在 renderer 或框架變動時重用。
+- 大量幾何邏輯散在元件內部，單元測試不足。
+
+## 2. 目標
+
+- 以農民工作流重設入口：先區分「植栽規劃」與「設施規劃」。
+- 建立可配置的格線與吸附策略。
+- 將關鍵幾何運算抽為純函式，降低 UI library 綁定。
+- 保持與現有 planner events、timeline replay、map import 向後相容。
+- 提供 WebGL renderer 遷移路徑（不在本次一次到位替換）。
+
+## 3. Farmer Workflow V2
+
+### 3.1 新增流程
+
+1. 使用者選擇入口：
+- `新增植栽區`
+- `新增設施區`
+
+2. 系統以項目尺寸 + 田區占用狀態進行自動落位。
+
+3. 使用者進一步進行：
+- 拖曳調整位置
+- 區域切分/合併
+- 更改植栽或設施屬性
+
+### 3.2 格線流程
+
+- 可設定格線密度：`0.5m`、`1m`、`2m`
+- 可切換顯示/隱藏格線
+- Snap 行為跟隨格線密度，不再硬編碼 0.5m
+
+## 4. 資訊架構調整
+
+## 4.1 工具列分流
+
+`FieldToolbar` 由單一 `新增作物` 入口拆為：
+- 植栽入口：只顯示非 `其它類` 類別
+- 設施入口：只顯示 `其它類` 類別
+
+雖然底層仍沿用 `PlantedCrop` 事件模型，但 UI 明確分流，避免「房舍=作物」的錯誤心智模型。
+
+## 4.2 設施語意
+
+- 設施入口文案使用「設施」而非「作物」。
+- 保留既有 `facilityType/facilityName` 欄位。
+
+## 5. 幾何與狀態架構
+
+## 5.1 Grid 設定模型
+
+新增純資料模型（localStorage persist）：
+- `showGrid: boolean`
+- `gridSizeMeters: 0.5 | 1 | 2`
+- `snapToGrid: boolean`
+
+預設值：`showGrid=true`, `gridSizeMeters=1`, `snapToGrid=true`。
+
+## 5.2 Auto Placement
+
+建立 `planner-placement` 純函式模組：
+- 輸入：field 尺寸、已占用區、新項目尺寸、掃描步距
+- 輸出：下一個可用座標
+
+策略：
+- 以左上到右下掃描候選點
+- 避免與既有 growing 區域重疊
+- 若無完整空位，回傳 fallback（邊界安全位置）
+
+## 5.3 Grid 計算
+
+建立 `planner-grid` 純函式模組：
+- 依 field 尺寸與 `gridSizeMeters` 產生線段/標籤座標
+- 與 renderer 解耦（回傳資料，不回傳 Konva 元件）
+
+## 6. Renderer 解耦與 WebGL Path
+
+## 6.1 本次實作
+
+- `FieldCanvas` 僅負責把純函式輸出映射為 Konva primitive。
+- 幾何計算不依賴 Konva event/object 型別。
+
+## 6.2 遷移路徑（後續）
+
+Phase A（本次）
+- 抽離計算邏輯與互動設定，確保可測。
+
+Phase B
+- 引入 renderer adapter：
+  - `toKonvaPrimitives(gridModel)`
+  - `toWebGLDrawCalls(gridModel)`
+
+Phase C
+- 以 Pixi/WebGL 實作 grid + static layers。
+- 保留編輯控制層（drag/resize semantics）不變。
+
+## 7. 相容性
+
+- 不修改 planner events schema。
+- 不改動 `PlantedCrop` 儲存格式。
+- timeline replay、map import 直接沿用。
+
+## 8. 驗收與測試
+
+### 8.1 單元測試
+
+- `planner-placement.test.ts`
+  - 空畫布落位
+  - 避讓占用區
+  - 無空位 fallback
+
+- `planner-grid.test.ts`
+  - 0.5/1/2m 線段數量與座標
+  - 標籤間距
+
+- `field-toolbar` 相關純函式測試
+  - 植栽清單不含 `其它類`
+  - 設施清單只含 `其它類`
+
+### 8.2 回歸檢查
+
+- `bun run lint`
+- `bunx tsc --noEmit`
+- `bun test`
+
+## 9. 風險
+
+- UI 分流但底層仍是 `PlantedCrop`，語意仍為過渡方案。
+- WebGL 仍需後續 phase 才能完整替換 renderer。
+
+## 10. 交付結果
+
+本次交付的價值在於：
+- 使用流程可理解度提升（植栽/設施分流）。
+- 空間放置更貼近田區實況（occupancy-aware）。
+- Grid 與幾何邏輯可測且可遷移，為 WebGL 重構鋪路。

--- a/src/app/field-planner/page.tsx
+++ b/src/app/field-planner/page.tsx
@@ -20,6 +20,7 @@ import {
   defaultUtilityVisibilitySettings,
   normalizeUtilityVisibilitySettings,
 } from "@/lib/utils/utility-visibility-settings";
+import { defaultPlannerGridSettings, normalizePlannerGridSettings } from "@/lib/utils/planner-grid-settings";
 import { normalizeTimelineSelectedDate } from "@/lib/utils/timeline-date";
 import { Trash2, Move, MousePointer, AlertTriangle } from "lucide-react";
 
@@ -86,6 +87,7 @@ export default function FieldPlannerPage() {
     "hualien-utility-visibility",
     defaultUtilityVisibilitySettings
   );
+  const [rawGridSettings, setRawGridSettings] = useLocalStorage("hualien-planner-grid-settings", defaultPlannerGridSettings);
   const [rawTimelineDate, setRawTimelineDate] = useLocalStorage("hualien-planner-timeline-date", "");
   const [remoteTimelineEvents, setRemoteTimelineEvents] = useState<PlannerEvent[] | null>(null);
   const [remoteAnchors, setRemoteAnchors] = useState<string[] | null>(null);
@@ -127,6 +129,7 @@ export default function FieldPlannerPage() {
     () => normalizeUtilityVisibilitySettings(rawUtilityVisibility),
     [rawUtilityVisibility]
   );
+  const gridSettings = useMemo(() => normalizePlannerGridSettings(rawGridSettings), [rawGridSettings]);
   const timelineDate = useMemo(() => normalizeTimelineSelectedDate(rawTimelineDate), [rawTimelineDate]);
 
   const timelineAnchors = useMemo(() => {
@@ -348,6 +351,13 @@ export default function FieldPlannerPage() {
                             return { ...current, showElectricUtilities: !current.showElectricUtilities };
                           });
                         }}
+                        gridSettings={gridSettings}
+                        onUpdateGridSettings={(updates) =>
+                          setRawGridSettings((prev) => {
+                            const current = normalizePlannerGridSettings(prev);
+                            return normalizePlannerGridSettings({ ...current, ...updates });
+                          })
+                        }
                       />
                       <MapImportDialog field={field} occurredAt={currentOccurredAt} />
                       <Button size="sm" variant={resizeMode ? "default" : "outline"} onClick={() => setResizeMode(!resizeMode)}>
@@ -398,6 +408,7 @@ export default function FieldPlannerPage() {
                     showUtilities={utilityVisibility.showUtilities}
                     showWaterUtilities={utilityVisibility.showWaterUtilities}
                     showElectricUtilities={utilityVisibility.showElectricUtilities}
+                    gridSettings={gridSettings}
                   />
                 </TabsContent>
               ))}

--- a/src/lib/utils/planner-grid-settings.test.ts
+++ b/src/lib/utils/planner-grid-settings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultPlannerGridSettings,
+  normalizePlannerGridSettings,
+} from "@/lib/utils/planner-grid-settings";
+
+describe("normalizePlannerGridSettings", () => {
+  it("returns defaults for invalid input", () => {
+    expect(normalizePlannerGridSettings(null)).toEqual(defaultPlannerGridSettings);
+  });
+
+  it("keeps valid values", () => {
+    expect(
+      normalizePlannerGridSettings({
+        showGrid: false,
+        gridSizeMeters: 0.5,
+        snapToGrid: false,
+      })
+    ).toEqual({
+      showGrid: false,
+      gridSizeMeters: 0.5,
+      snapToGrid: false,
+    });
+  });
+
+  it("falls back for invalid grid size", () => {
+    expect(
+      normalizePlannerGridSettings({
+        showGrid: true,
+        gridSizeMeters: 3,
+        snapToGrid: true,
+      })
+    ).toEqual(defaultPlannerGridSettings);
+  });
+});

--- a/src/lib/utils/planner-grid-settings.ts
+++ b/src/lib/utils/planner-grid-settings.ts
@@ -1,0 +1,29 @@
+export const plannerGridSizeOptions = [0.5, 1, 2] as const;
+
+export type PlannerGridSizeMeters = (typeof plannerGridSizeOptions)[number];
+
+export interface PlannerGridSettings {
+  showGrid: boolean;
+  gridSizeMeters: PlannerGridSizeMeters;
+  snapToGrid: boolean;
+}
+
+export const defaultPlannerGridSettings: PlannerGridSettings = {
+  showGrid: true,
+  gridSizeMeters: 1,
+  snapToGrid: true,
+};
+
+function isGridSizeMeters(value: unknown): value is PlannerGridSizeMeters {
+  return typeof value === "number" && plannerGridSizeOptions.includes(value as PlannerGridSizeMeters);
+}
+
+export function normalizePlannerGridSettings(input: unknown): PlannerGridSettings {
+  if (!input || typeof input !== "object") return defaultPlannerGridSettings;
+  const raw = input as Partial<PlannerGridSettings>;
+  return {
+    showGrid: typeof raw.showGrid === "boolean" ? raw.showGrid : defaultPlannerGridSettings.showGrid,
+    gridSizeMeters: isGridSizeMeters(raw.gridSizeMeters) ? raw.gridSizeMeters : defaultPlannerGridSettings.gridSizeMeters,
+    snapToGrid: typeof raw.snapToGrid === "boolean" ? raw.snapToGrid : defaultPlannerGridSettings.snapToGrid,
+  };
+}

--- a/src/lib/utils/planner-grid.test.ts
+++ b/src/lib/utils/planner-grid.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildPlannerGridLines, snapToGrid } from "@/lib/utils/planner-grid";
+
+describe("buildPlannerGridLines", () => {
+  it("builds 1m grid lines with labels", () => {
+    const lines = buildPlannerGridLines(3, 2, 100, 1);
+    expect(lines.length).toBe(7);
+    expect(lines.filter((line) => line.label !== null).length).toBe(7);
+  });
+
+  it("builds minor lines for 0.5m grid", () => {
+    const lines = buildPlannerGridLines(1, 1, 100, 0.5);
+    expect(lines.length).toBe(6);
+    expect(lines.filter((line) => line.major).length).toBe(4);
+    expect(lines.filter((line) => line.label !== null).length).toBe(4);
+  });
+
+  it("includes trailing boundary when size is not divisible", () => {
+    const lines = buildPlannerGridLines(2.2, 1.2, 100, 1);
+    const verticalMeters = lines.filter((line) => line.orientation === "vertical").map((line) => line.meter);
+    const horizontalMeters = lines.filter((line) => line.orientation === "horizontal").map((line) => line.meter);
+    expect(verticalMeters).toContain(2.2);
+    expect(horizontalMeters).toContain(1.2);
+  });
+});
+
+describe("snapToGrid", () => {
+  it("snaps to nearest step", () => {
+    expect(snapToGrid(143, 50, 0)).toBe(150);
+  });
+
+  it("clamps at minimum", () => {
+    expect(snapToGrid(3, 10, 5)).toBe(5);
+  });
+});

--- a/src/lib/utils/planner-grid.ts
+++ b/src/lib/utils/planner-grid.ts
@@ -1,0 +1,76 @@
+import type { PlannerGridSizeMeters } from "@/lib/utils/planner-grid-settings";
+
+export interface PlannerGridLine {
+  orientation: "vertical" | "horizontal";
+  position: number;
+  meter: number;
+  major: boolean;
+  label: string | null;
+}
+
+function roundMeter(value: number) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function buildAxisMeters(limit: number, step: PlannerGridSizeMeters): number[] {
+  if (limit <= 0) return [0];
+  const count = Math.floor(limit / step);
+  const meters: number[] = [];
+
+  for (let i = 0; i <= count; i += 1) {
+    meters.push(roundMeter(i * step));
+  }
+
+  const last = meters[meters.length - 1] ?? 0;
+  if (Math.abs(last - limit) > 0.0001) {
+    meters.push(roundMeter(limit));
+  }
+
+  return meters;
+}
+
+function isMajorMeter(meter: number) {
+  return Math.abs(meter - Math.round(meter)) < 0.0001;
+}
+
+export function buildPlannerGridLines(
+  widthMeters: number,
+  heightMeters: number,
+  pixelsPerMeter: number,
+  gridSizeMeters: PlannerGridSizeMeters
+): PlannerGridLine[] {
+  if (widthMeters < 0 || heightMeters < 0 || pixelsPerMeter <= 0) return [];
+
+  const verticalMeters = buildAxisMeters(widthMeters, gridSizeMeters);
+  const horizontalMeters = buildAxisMeters(heightMeters, gridSizeMeters);
+
+  const verticalLines = verticalMeters.map((meter) => {
+    const major = isMajorMeter(meter);
+    return {
+      orientation: "vertical" as const,
+      meter,
+      position: meter * pixelsPerMeter,
+      major,
+      label: major ? `${Math.round(meter)}m` : null,
+    };
+  });
+
+  const horizontalLines = horizontalMeters.map((meter) => {
+    const major = isMajorMeter(meter);
+    return {
+      orientation: "horizontal" as const,
+      meter,
+      position: meter * pixelsPerMeter,
+      major,
+      label: major ? `${Math.round(meter)}m` : null,
+    };
+  });
+
+  return [...verticalLines, ...horizontalLines];
+}
+
+export function snapToGrid(value: number, step: number, min = 0): number {
+  if (!Number.isFinite(value)) return min;
+  if (!Number.isFinite(step) || step <= 0) return Math.max(min, value);
+  return Math.max(min, Math.round(value / step) * step);
+}

--- a/src/lib/utils/planner-item-groups.test.ts
+++ b/src/lib/utils/planner-item-groups.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { Crop } from "@/lib/types";
+import { CropCategory, SunlightLevel, WaterLevel } from "@/lib/types";
+import { splitPlannerItemsByUsage } from "@/lib/utils/planner-item-groups";
+
+function makeCrop(id: string, category: CropCategory): Crop {
+  return {
+    id,
+    name: id,
+    emoji: "🌱",
+    color: "#22c55e",
+    schemaVersion: 2,
+    category,
+    plantingMonths: [1],
+    harvestMonths: [2],
+    growthDays: 30,
+    spacing: { row: 30, plant: 30 },
+    water: WaterLevel.適量,
+    sunlight: SunlightLevel.全日照,
+    temperatureRange: { min: 15, max: 30 },
+    soilPhRange: { min: 6, max: 7 },
+    pestSusceptibility: "低",
+    yieldEstimateKgPerSqm: 1,
+    stageProfiles: {},
+    fertilizerIntervalDays: 14,
+    needsPruning: false,
+    pestControl: [],
+    typhoonResistance: "中",
+    hualienNotes: "",
+  };
+}
+
+describe("splitPlannerItemsByUsage", () => {
+  it("separates crops and facilities by category", () => {
+    const { cropItems, facilityItems } = splitPlannerItemsByUsage([
+      makeCrop("tomato", CropCategory.茄果類),
+      makeCrop("facility-house", CropCategory.其它類),
+      makeCrop("flower", CropCategory.花草園藝),
+    ]);
+
+    expect(cropItems.map((item) => item.id)).toEqual(["tomato", "flower"]);
+    expect(facilityItems.map((item) => item.id)).toEqual(["facility-house"]);
+  });
+});

--- a/src/lib/utils/planner-item-groups.ts
+++ b/src/lib/utils/planner-item-groups.ts
@@ -1,0 +1,9 @@
+import type { Crop } from "@/lib/types";
+import { isInfrastructureCategory } from "@/lib/types";
+
+export function splitPlannerItemsByUsage(crops: Crop[]) {
+  return {
+    cropItems: crops.filter((crop) => !isInfrastructureCategory(crop.category)),
+    facilityItems: crops.filter((crop) => isInfrastructureCategory(crop.category)),
+  };
+}

--- a/src/lib/utils/planner-placement.test.ts
+++ b/src/lib/utils/planner-placement.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { findNextPlannerPlacement } from "@/lib/utils/planner-placement";
+
+describe("findNextPlannerPlacement", () => {
+  it("returns origin on empty field", () => {
+    expect(
+      findNextPlannerPlacement(
+        { width: 200, height: 200 },
+        { width: 50, height: 50 },
+        []
+      )
+    ).toEqual({ x: 0, y: 0 });
+  });
+
+  it("skips occupied areas", () => {
+    const placement = findNextPlannerPlacement(
+      { width: 200, height: 200 },
+      { width: 50, height: 50 },
+      [{ x: 0, y: 0, width: 70, height: 70 }],
+      { step: 10, padding: 0 }
+    );
+    expect(placement.x).toBeGreaterThanOrEqual(70);
+    expect(placement.y).toBe(0);
+  });
+
+  it("returns lower-right fallback when no slot is available", () => {
+    expect(
+      findNextPlannerPlacement(
+        { width: 100, height: 100 },
+        { width: 80, height: 80 },
+        [{ x: 0, y: 0, width: 100, height: 100 }]
+      )
+    ).toEqual({ x: 20, y: 20 });
+  });
+});

--- a/src/lib/utils/planner-placement.ts
+++ b/src/lib/utils/planner-placement.ts
@@ -1,0 +1,64 @@
+export interface PlannerPlacementRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PlannerPlacementBounds {
+  width: number;
+  height: number;
+}
+
+export interface PlannerPlacementOptions {
+  step?: number;
+  padding?: number;
+}
+
+function clampSizeToBounds(size: { width: number; height: number }, bounds: PlannerPlacementBounds) {
+  return {
+    width: Math.max(1, Math.min(size.width, bounds.width)),
+    height: Math.max(1, Math.min(size.height, bounds.height)),
+  };
+}
+
+function overlaps(a: PlannerPlacementRect, b: PlannerPlacementRect, padding = 0) {
+  return !(
+    a.x + a.width + padding <= b.x ||
+    b.x + b.width + padding <= a.x ||
+    a.y + a.height + padding <= b.y ||
+    b.y + b.height + padding <= a.y
+  );
+}
+
+export function findNextPlannerPlacement(
+  bounds: PlannerPlacementBounds,
+  size: { width: number; height: number },
+  occupied: PlannerPlacementRect[],
+  options?: PlannerPlacementOptions
+) {
+  const step = Math.max(5, options?.step ?? 20);
+  const padding = Math.max(0, options?.padding ?? 6);
+  const safeBounds = {
+    width: Math.max(1, bounds.width),
+    height: Math.max(1, bounds.height),
+  };
+  const targetSize = clampSizeToBounds(size, safeBounds);
+  const maxX = Math.max(0, safeBounds.width - targetSize.width);
+  const maxY = Math.max(0, safeBounds.height - targetSize.height);
+
+  for (let y = 0; y <= maxY; y += step) {
+    for (let x = 0; x <= maxX; x += step) {
+      const candidate = { x, y, width: targetSize.width, height: targetSize.height };
+      if (!occupied.some((rect) => overlaps(candidate, rect, padding))) {
+        return { x, y };
+      }
+    }
+  }
+
+  // Fallback: stick to the closest valid corner inside bounds.
+  return {
+    x: maxX,
+    y: maxY,
+  };
+}


### PR DESCRIPTION
## Summary
- redesign field planner add-flow into two explicit workflows: `新增植栽區` and `新增設施區`
- replace rigid fixed-column placement with occupancy-aware auto placement
- add configurable grid controls (show/hide, 0.5m/1m/2m density, snap on/off) persisted in localStorage
- refactor grid math into pure utilities to reduce renderer coupling and prepare WebGL migration path
- add Grid Planner V2 design doc for issue #80

## Changes
- `src/components/field-planner/field-toolbar.tsx`
  - split crop/facility entry points
  - add grid settings popover
  - use occupancy-aware placement utility
- `src/components/field-planner/field-canvas.tsx`
  - use normalized grid model instead of hardcoded 1m line generation
  - apply configurable snap behavior to drag/resize
- `src/app/field-planner/page.tsx`
  - persist/read grid settings and pass down to toolbar/canvas
- new utilities:
  - `src/lib/utils/planner-grid-settings.ts`
  - `src/lib/utils/planner-grid.ts`
  - `src/lib/utils/planner-placement.ts`
  - `src/lib/utils/planner-item-groups.ts`
- tests:
  - `src/lib/utils/planner-grid-settings.test.ts`
  - `src/lib/utils/planner-grid.test.ts`
  - `src/lib/utils/planner-placement.test.ts`
  - `src/lib/utils/planner-item-groups.test.ts`
- design doc:
  - `docs/plans/2026-02-18-grid-planner-v2-redesign.md`

## Validation
- `bun run lint`
- `bunx tsc --noEmit`
- `bun test`

Closes #80
